### PR TITLE
feat(leaderboard): connect UI to real PostgreSQL database

### DIFF
--- a/frontend/app/leaderboard/page.tsx
+++ b/frontend/app/leaderboard/page.tsx
@@ -1,85 +1,10 @@
-'use client';
+import { getLeaderboardData } from '@/db/queries/leaderboard';
+import LeaderboardClient from '@/components/leaderboard/LeaderboardClient';
 
-import { useState } from 'react';
-import { LeaderboardTabs } from '@/components/leaderboard/LeaderboardTabs';
-import { LeaderboardPodium } from '@/components/leaderboard/LeaderboardPodium';
-import { LeaderboardTable } from '@/components/leaderboard/LeaderboardTable';
-import { User } from '@/components/leaderboard/types';
-import { Trophy } from 'lucide-react';
+export const dynamic = 'force-dynamic';
 
-const generateData = (tab: string): User[] => {
-  const seed = tab.length * 5;
-  return Array.from({ length: 15 }).map((_, i) => ({
-    id: i + 1,
-    rank: i + 1,
-    username:
-      [
-        'som-sm',
-        'sanjana',
-        'satohshi',
-        'Cristopher',
-        'Saad Khan',
-        'AlexDev',
-        'CodeMaster',
-        'NextGuru',
-        'ReactFan',
-        'WebWizard',
-        'VercelPro',
-        'NeonUser',
-        'DrizzleKing',
-        'TypeHero',
-        'CSSArtist',
-      ][i] || `User${i + 1}`,
-    points: 2500 - i * 50 + seed,
-    avatar: '',
-    change: Math.floor(Math.random() * 10) - 2,
-  }));
-};
+export default async function LeaderboardPage() {
+  const users = await getLeaderboardData();
 
-export default function LeaderboardPage() {
-  const [activeTab, setActiveTab] = useState('Overall');
-
-  const allUsers = generateData(activeTab);
-  const topThree = allUsers.slice(0, 3);
-  const otherUsers = allUsers.slice(3);
-
-  return (
-    <div className="relative min-h-screen overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-b from-sky-50 via-white to-rose-50 dark:from-slate-950 dark:via-slate-950 dark:to-black -z-20" />
-      <div className="pointer-events-none absolute inset-0 opacity-70 -z-10">
-        <div className="absolute -top-32 left-1/2 h-96 w-[36rem] -translate-x-1/2 rounded-full bg-sky-300/30 blur-3xl dark:bg-sky-500/20" />
-        <div className="absolute bottom-[-12rem] left-1/4 h-[22rem] w-[22rem] rounded-full bg-pink-300/30 blur-3xl dark:bg-fuchsia-500/20" />
-        <div className="absolute bottom-[-10rem] right-0 h-[26rem] w-[26rem] rounded-full bg-violet-300/40 blur-3xl dark:bg-violet-500/20" />
-      </div>
-
-      <main className="relative max-w-4xl mx-auto px-4 py-12 flex flex-col items-center z-10">
-        <div className="mb-10 text-center">
-          <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight flex items-center justify-center gap-3 mb-4 drop-shadow-sm">
-            <Trophy
-              className="w-10 h-10 md:w-12 md:h-12 text-yellow-500 fill-yellow-500"
-              strokeWidth={1.5}
-            />
-            <span className="bg-gradient-to-r from-slate-900 to-slate-700 dark:from-white dark:to-slate-300 bg-clip-text text-transparent">
-              Leaderboard
-            </span>
-          </h1>
-          <p className="text-slate-600 dark:text-slate-400 font-medium text-lg">
-            Top performers of the community.
-          </p>
-        </div>
-
-        <div className="mb-10">
-          <LeaderboardTabs activeTab={activeTab} onTabChange={setActiveTab} />
-        </div>
-
-        <div className="w-full mb-12">
-          <LeaderboardPodium topThree={topThree} />
-        </div>
-
-        <div className="w-full animate-in fade-in slide-in-from-bottom-8 duration-700">
-          <LeaderboardTable users={otherUsers} />
-        </div>
-      </main>
-    </div>
-  );
+  return <LeaderboardClient initialUsers={users} />;
 }

--- a/frontend/components/leaderboard/LeaderboardClient.tsx
+++ b/frontend/components/leaderboard/LeaderboardClient.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import { LeaderboardTabs } from './LeaderboardTabs';
+import { LeaderboardPodium } from './LeaderboardPodium';
+import { LeaderboardTable } from './LeaderboardTable';
+import { User } from './types';
+import { Trophy } from 'lucide-react';
+
+interface LeaderboardClientProps {
+  initialUsers: User[];
+}
+
+export default function LeaderboardClient({
+  initialUsers,
+}: LeaderboardClientProps) {
+  const [activeTab, setActiveTab] = useState('Overall');
+
+  const allUsers = initialUsers;
+
+  const topThree = allUsers.slice(0, 3);
+  const otherUsers = allUsers.slice(3);
+
+  return (
+    <div className="relative min-h-screen overflow-hidden">
+      {/* Background */}
+      <div className="absolute inset-0 bg-gradient-to-b from-sky-50 via-white to-rose-50 dark:from-slate-950 dark:via-slate-950 dark:to-black -z-20" />
+      <div className="pointer-events-none absolute inset-0 opacity-70 -z-10">
+        <div className="absolute -top-32 left-1/2 h-96 w-[36rem] -translate-x-1/2 rounded-full bg-sky-300/30 blur-3xl dark:bg-sky-500/20" />
+        <div className="absolute bottom-[-12rem] left-1/4 h-[22rem] w-[22rem] rounded-full bg-pink-300/30 blur-3xl dark:bg-fuchsia-500/20" />
+        <div className="absolute bottom-[-10rem] right-0 h-[26rem] w-[26rem] rounded-full bg-violet-300/40 blur-3xl dark:bg-violet-500/20" />
+      </div>
+
+      <main className="relative max-w-4xl mx-auto px-4 py-12 flex flex-col items-center z-10">
+        <div className="mb-10 text-center">
+          <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight flex items-center justify-center gap-3 mb-4 drop-shadow-sm">
+            <Trophy
+              className="w-10 h-10 md:w-12 md:h-12 text-yellow-500 fill-yellow-500"
+              strokeWidth={1.5}
+            />
+            <span className="bg-gradient-to-r from-slate-900 to-slate-700 dark:from-white dark:to-slate-300 bg-clip-text text-transparent">
+              Leaderboard
+            </span>
+          </h1>
+          <p className="text-slate-600 dark:text-slate-400 font-medium text-lg">
+            Top performers of the community.
+          </p>
+        </div>
+
+        <div className="mb-10">
+          <LeaderboardTabs activeTab={activeTab} onTabChange={setActiveTab} />
+        </div>
+
+        <div className="w-full mb-12">
+          <LeaderboardPodium topThree={topThree} />
+        </div>
+
+        <div className="w-full animate-in fade-in slide-in-from-bottom-8 duration-700">
+          <LeaderboardTable users={otherUsers} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/db/index.ts
+++ b/frontend/db/index.ts
@@ -1,6 +1,9 @@
 import { drizzle } from 'drizzle-orm/neon-http';
 import { neon } from '@neondatabase/serverless';
 import * as schema from './schema/index';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env' });
 
 if (!process.env.DATABASE_URL) {
   throw new Error('DATABASE_URL is missing');

--- a/frontend/db/queries/leaderboard.ts
+++ b/frontend/db/queries/leaderboard.ts
@@ -1,0 +1,26 @@
+import { db } from '../index';
+import { users } from '../schema/users';
+import { desc } from 'drizzle-orm';
+import { User } from '@/components/leaderboard/types';
+
+export async function getLeaderboardData(): Promise<User[]> {
+  const dbUsers = await db
+    .select({
+      id: users.id,
+      username: users.name,
+      points: users.points,
+      avatar: users.image,
+    })
+    .from(users)
+    .orderBy(desc(users.points))
+    .limit(50);
+
+  return dbUsers.map((u, index) => ({
+    id: index + 1,
+    rank: index + 1,
+    username: u.username || 'Anonymous',
+    points: u.points || 0,
+    avatar: u.avatar || '',
+    change: 0,
+  }));
+}

--- a/frontend/db/schema/index.ts
+++ b/frontend/db/schema/index.ts
@@ -1,4 +1,6 @@
- // Export categories schemas
-  export * from './categories';
-  // Export quiz schemas
-  export * from './quiz';
+// Export categories schemas
+export * from './categories';
+// Export quiz schemas
+export * from './quiz';
+// Export user schemas
+export * from './users';

--- a/frontend/db/schema/users.ts
+++ b/frontend/db/schema/users.ts
@@ -1,0 +1,23 @@
+import {
+  pgTable,
+  text,
+  integer,
+  timestamp,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { quizAttempts } from './quiz';
+
+export const users = pgTable('user', {
+  id: text('id').primaryKey().notNull(),
+  name: text('name'),
+  email: text('email').notNull().unique(),
+  emailVerified: timestamp('emailVerified', { mode: 'date' }),
+  image: text('image'),
+  role: text('role').default('user'),
+  points: integer('points').default(0),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const usersRelations = relations(users, ({ many }) => ({
+  attempts: many(quizAttempts),
+}));

--- a/frontend/db/seed-users.ts
+++ b/frontend/db/seed-users.ts
@@ -1,0 +1,74 @@
+import { db } from './index';
+import { users } from './schema/users';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env' });
+
+const mockUsers = [
+  {
+    id: 'user_1',
+    name: 'som-sm',
+    points: 2535,
+    role: 'user',
+    email: 'som@test.com',
+  },
+  {
+    id: 'user_2',
+    name: 'sanjana',
+    points: 2485,
+    role: 'user',
+    email: 'sanjana@test.com',
+  },
+  {
+    id: 'user_3',
+    name: 'satohshi',
+    points: 2435,
+    role: 'user',
+    email: 'sat@test.com',
+  },
+  {
+    id: 'user_4',
+    name: 'Cristopher',
+    points: 2385,
+    role: 'user',
+    email: 'cris@test.com',
+  },
+  {
+    id: 'user_5',
+    name: 'Saad Khan',
+    points: 2335,
+    role: 'user',
+    email: 'saad@test.com',
+  },
+  {
+    id: 'user_6',
+    name: 'AlexDev',
+    points: 2285,
+    role: 'admin',
+    email: 'alex@test.com',
+  },
+  {
+    id: 'user_7',
+    name: 'CodeMaster',
+    points: 2235,
+    role: 'user',
+    email: 'code@test.com',
+  },
+];
+
+async function main() {
+  console.log('🌱 Seeding users...');
+
+  try {
+    for (const user of mockUsers) {
+      await db.insert(users).values(user).onConflictDoNothing();
+    }
+    console.log('✅ Users seeded successfully!');
+  } catch (error) {
+    console.error('❌ Error seeding users:', error);
+  } finally {
+    process.exit(0);
+  }
+}
+
+main();

--- a/frontend/drizzle/0003_fine_makkari.sql
+++ b/frontend/drizzle/0003_fine_makkari.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "user" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text,
+	"email" text NOT NULL,
+	"emailVerified" timestamp,
+	"image" text,
+	"role" text DEFAULT 'user',
+	"points" integer DEFAULT 0,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+ALTER TABLE "quiz_attempts" ALTER COLUMN "user_id" SET DATA TYPE text;

--- a/frontend/drizzle/meta/0003_snapshot.json
+++ b/frontend/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,866 @@
+{
+  "id": "d5bb3ee6-3f9b-47ce-9a82-8bc0887181ea",
+  "prevId": "07895dfd-e1a1-43e3-bdf5-964addd43a6a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_blocks": {
+          "name": "answer_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_category_id_categories_id_fk": {
+          "name": "questions_category_id_categories_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_answer_translations": {
+      "name": "quiz_answer_translations",
+      "schema": "",
+      "columns": {
+        "quiz_answer_id": {
+          "name": "quiz_answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_text": {
+          "name": "answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_answer_translations_quiz_answer_id_quiz_answers_id_fk": {
+          "name": "quiz_answer_translations_quiz_answer_id_quiz_answers_id_fk",
+          "tableFrom": "quiz_answer_translations",
+          "tableTo": "quiz_answers",
+          "columnsFrom": [
+            "quiz_answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quiz_answer_translations_quiz_answer_id_locale_pk": {
+          "name": "quiz_answer_translations_quiz_answer_id_locale_pk",
+          "columns": [
+            "quiz_answer_id",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_answers": {
+      "name": "quiz_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quiz_question_id": {
+          "name": "quiz_question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "quiz_answers_question_display_order_idx": {
+          "name": "quiz_answers_question_display_order_idx",
+          "columns": [
+            {
+              "expression": "quiz_question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_answers_quiz_question_id_quiz_questions_id_fk": {
+          "name": "quiz_answers_quiz_question_id_quiz_questions_id_fk",
+          "tableFrom": "quiz_answers",
+          "tableTo": "quiz_questions",
+          "columnsFrom": [
+            "quiz_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_attempt_answers": {
+      "name": "quiz_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quiz_question_id": {
+          "name": "quiz_question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_answer_id": {
+          "name": "selected_answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quiz_attempt_answers_attempt_idx": {
+          "name": "quiz_attempt_answers_attempt_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_attempt_answers_attempt_id_quiz_attempts_id_fk": {
+          "name": "quiz_attempt_answers_attempt_id_quiz_attempts_id_fk",
+          "tableFrom": "quiz_attempt_answers",
+          "tableTo": "quiz_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_attempt_answers_quiz_question_id_quiz_questions_id_fk": {
+          "name": "quiz_attempt_answers_quiz_question_id_quiz_questions_id_fk",
+          "tableFrom": "quiz_attempt_answers",
+          "tableTo": "quiz_questions",
+          "columnsFrom": [
+            "quiz_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_attempt_answers_selected_answer_id_quiz_answers_id_fk": {
+          "name": "quiz_attempt_answers_selected_answer_id_quiz_answers_id_fk",
+          "tableFrom": "quiz_attempt_answers",
+          "tableTo": "quiz_answers",
+          "columnsFrom": [
+            "selected_answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_attempts": {
+      "name": "quiz_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_questions": {
+          "name": "total_questions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_spent_seconds": {
+          "name": "time_spent_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrity_score": {
+          "name": "integrity_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 100
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quiz_attempts_user_completed_at_idx": {
+          "name": "quiz_attempts_user_completed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quiz_attempts_quiz_percentage_completed_at_idx": {
+          "name": "quiz_attempts_quiz_percentage_completed_at_idx",
+          "columns": [
+            {
+              "expression": "quiz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "percentage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quiz_attempts_quiz_integrity_score_idx": {
+          "name": "quiz_attempts_quiz_integrity_score_idx",
+          "columns": [
+            {
+              "expression": "quiz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_attempts_quiz_id_quizzes_id_fk": {
+          "name": "quiz_attempts_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_question_content": {
+      "name": "quiz_question_content",
+      "schema": "",
+      "columns": {
+        "quiz_question_id": {
+          "name": "quiz_question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_question_content_quiz_question_id_quiz_questions_id_fk": {
+          "name": "quiz_question_content_quiz_question_id_quiz_questions_id_fk",
+          "tableFrom": "quiz_question_content",
+          "tableTo": "quiz_questions",
+          "columnsFrom": [
+            "quiz_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quiz_question_content_quiz_question_id_locale_pk": {
+          "name": "quiz_question_content_quiz_question_id_locale_pk",
+          "columns": [
+            "quiz_question_id",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_questions": {
+      "name": "quiz_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_question_id": {
+          "name": "source_question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'medium'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quiz_questions_quiz_display_order_idx": {
+          "name": "quiz_questions_quiz_display_order_idx",
+          "columns": [
+            {
+              "expression": "quiz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_questions_quiz_id_quizzes_id_fk": {
+          "name": "quiz_questions_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_questions",
+          "tableTo": "quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_translations": {
+      "name": "quiz_translations",
+      "schema": "",
+      "columns": {
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_translations_quiz_id_quizzes_id_fk": {
+          "name": "quiz_translations_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_translations",
+          "tableTo": "quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quiz_translations_quiz_id_locale_pk": {
+          "name": "quiz_translations_quiz_id_locale_pk",
+          "columns": [
+            "quiz_id",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quizzes": {
+      "name": "quizzes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "questions_count": {
+          "name": "questions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "time_limit_seconds": {
+          "name": "time_limit_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "quizzes_topic_id_slug_unique": {
+          "name": "quizzes_topic_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/frontend/drizzle/meta/_journal.json
+++ b/frontend/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1764781450263,
       "tag": "0002_fantastic_retro_girl",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1765197457538,
+      "tag": "0003_fine_makkari",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "seed:categories": "tsx db/seedCategories.ts",
     "seed": "tsx db/seed.ts",
+    "seed:users": "tsx db/seed-users.ts",
     "parse": "tsx db_script/script.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Changes
- **Database:** Added `users` schema, relations with `quizAttempts`, and seeding script.
- **Backend:** Implemented Server Component architecture for Leaderboard page using Drizzle ORM.
- **UI:** Redesigned Leaderboard using Glassmorphism, added Dark Mode support (fixed hardcoded styles).

## Technical Details
- Replaced mock data with real PostgreSQL queries via Drizzle.
- Optimized performance by fetching data on the server (RSC).
- Added `seed:users` script for development.