### PR TITLE
ref: admin api kill switch, orders id only owner or admin consistency…

### DIFF
--- a/frontend/app/api/shop/admin/products/[id]/route.ts
+++ b/frontend/app/api/shop/admin/products/[id]/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
-import { AdminApiDisabledError, requireAdminApi } from '@/lib/auth/admin';
+import {
+  AdminApiDisabledError,
+  AdminForbiddenError,
+  AdminUnauthorizedError,
+  requireAdminApi,
+} from '@/lib/auth/admin';
+
 import { parseAdminProductForm } from '@/lib/admin/parseAdminProductForm';
 import { logError } from '@/lib/logging';
 import { InvalidPayloadError, SlugConflictError } from '@/lib/services/errors';
@@ -33,7 +39,13 @@ export async function GET(
     return NextResponse.json({ product });
   } catch (error) {
     if (error instanceof AdminApiDisabledError) {
-      return NextResponse.json({ code: 'ADMIN_API_DISABLED' }, { status: 403 });
+      return NextResponse.json({ code: error.code }, { status: 403 });
+    }
+    if (error instanceof AdminUnauthorizedError) {
+      return NextResponse.json({ code: error.code }, { status: 401 });
+    }
+    if (error instanceof AdminForbiddenError) {
+      return NextResponse.json({ code: error.code }, { status: 403 });
     }
 
     logError('Failed to load admin product', error);
@@ -131,8 +143,15 @@ export async function PATCH(
     }
   } catch (error) {
     if (error instanceof AdminApiDisabledError) {
-      return NextResponse.json({ code: 'ADMIN_API_DISABLED' }, { status: 403 });
+      return NextResponse.json({ code: error.code }, { status: 403 });
     }
+    if (error instanceof AdminUnauthorizedError) {
+      return NextResponse.json({ code: error.code }, { status: 401 });
+    }
+    if (error instanceof AdminForbiddenError) {
+      return NextResponse.json({ code: error.code }, { status: 403 });
+    }
+
     logError('Admin PATCH /products/:id failed (outer)', error);
     return NextResponse.json(
       { error: 'Failed to process request' },
@@ -161,8 +180,15 @@ export async function DELETE(
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (error) {
     if (error instanceof AdminApiDisabledError) {
-      return NextResponse.json({ code: 'ADMIN_API_DISABLED' }, { status: 403 });
+      return NextResponse.json({ code: error.code }, { status: 403 });
     }
+    if (error instanceof AdminUnauthorizedError) {
+      return NextResponse.json({ code: error.code }, { status: 401 });
+    }
+    if (error instanceof AdminForbiddenError) {
+      return NextResponse.json({ code: error.code }, { status: 403 });
+    }
+
     logError('Failed to delete product', error);
 
     if (error instanceof Error && error.message === 'PRODUCT_NOT_FOUND') {

--- a/frontend/app/api/shop/admin/products/[id]/status/route.ts
+++ b/frontend/app/api/shop/admin/products/[id]/status/route.ts
@@ -1,35 +1,59 @@
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  AdminApiDisabledError,
+  AdminForbiddenError,
+  AdminUnauthorizedError,
+  requireAdminApi,
+} from '@/lib/auth/admin';
 
-import { AdminApiDisabledError, requireAdminApi } from "@/lib/auth/admin"
-import { logError } from "@/lib/logging"
-import { toggleProductStatus } from "@/lib/services/products"
+import { logError } from '@/lib/logging';
+import { toggleProductStatus } from '@/lib/services/products';
+
+const productIdParamSchema = z.object({ id: z.string().uuid() });
 
 export async function PATCH(
   request: NextRequest,
-  context: { params: Promise<{ id: string }> },
+  context: { params: Promise<{ id: string }> }
 ) {
   try {
-    await requireAdminApi(request)
+    await requireAdminApi(request);
 
-    const { id: productId } = await context.params
-
-    if (!productId) {
-      return NextResponse.json({ error: "Product id is required" }, { status: 400 })
+    const rawParams = await context.params;
+    const parsedParams = productIdParamSchema.safeParse(rawParams);
+    if (!parsedParams.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid product id',
+          code: 'INVALID_PRODUCT_ID',
+          details: parsedParams.error.format(),
+        },
+        { status: 400 }
+      );
     }
 
-    const updated = await toggleProductStatus(productId)
-    return NextResponse.json({ success: true, product: updated })
+    const productId = parsedParams.data.id;
+
+    const updated = await toggleProductStatus(productId);
+    return NextResponse.json({ success: true, product: updated });
   } catch (error) {
     if (error instanceof AdminApiDisabledError) {
-      return NextResponse.json({ code: "ADMIN_API_DISABLED" }, { status: 403 })
+      return NextResponse.json({ code: error.code }, { status: 403 });
     }
-    logError("Failed to update product status", error)
-    if (error instanceof Error && error.message === "PRODUCT_NOT_FOUND") {
-      return NextResponse.json({ error: "Product not found" }, { status: 404 })
+    if (error instanceof AdminUnauthorizedError) {
+      return NextResponse.json({ code: error.code }, { status: 401 });
+    }
+    if (error instanceof AdminForbiddenError) {
+      return NextResponse.json({ code: error.code }, { status: 403 });
+    }
+
+    logError('Failed to update product status', error);
+    if (error instanceof Error && error.message === 'PRODUCT_NOT_FOUND') {
+      return NextResponse.json({ error: 'Product not found' }, { status: 404 });
     }
     return NextResponse.json(
-      { error: "Failed to update product status" },
-      { status: 500 },
-    )
+      { error: 'Failed to update product status' },
+      { status: 500 }
+    );
   }
 }

--- a/frontend/app/api/shop/orders/[id]/route.ts
+++ b/frontend/app/api/shop/orders/[id]/route.ts
@@ -1,65 +1,73 @@
-import "server-only"
+import 'server-only';
 
-import { NextRequest, NextResponse } from "next/server"
-import { eq } from "drizzle-orm"
+import { NextRequest, NextResponse } from 'next/server';
+import { and, eq } from 'drizzle-orm';
 
-import { db } from "@/db"
-import { orderItems, orders } from "@/db/schema"
-import { getCurrentUser } from "@/lib/auth"
-import { orderIdParamSchema } from "@/lib/validation/shop"
-import { logError } from "@/lib/logging"
+import { db } from '@/db';
+import { orderItems, orders } from '@/db/schema';
+import { getCurrentUser } from '@/lib/auth';
+import { orderIdParamSchema } from '@/lib/validation/shop';
+import { logError } from '@/lib/logging';
 
-export const dynamic = "force-dynamic"
+export const dynamic = 'force-dynamic';
 
 function noStoreJson(body: unknown, init?: { status?: number }) {
-  const res = NextResponse.json(body, { status: init?.status ?? 200 })
-  res.headers.set("Cache-Control", "no-store")
-  return res
+  const res = NextResponse.json(body, { status: init?.status ?? 200 });
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
 }
 
 type OrderDetailResponse = {
-  id: string
-  userId: string | null
-  totalAmount: string
-  currency: "USD"
-  paymentStatus: "pending" | "requires_payment" | "paid" | "failed" | "refunded"
-  paymentProvider: string
-  paymentIntentId: string | null
-  stockRestored: boolean
-  restockedAt: string | null
-  idempotencyKey: string
-  createdAt: string
-  updatedAt: string
+  id: string;
+  userId: string | null;
+  totalAmount: string;
+  currency: 'USD';
+  paymentStatus:
+    | 'pending'
+    | 'requires_payment'
+    | 'paid'
+    | 'failed'
+    | 'refunded';
+  paymentProvider: string;
+  paymentIntentId: string | null;
+  stockRestored: boolean;
+  restockedAt: string | null;
+  idempotencyKey: string;
+  createdAt: string;
+  updatedAt: string;
   items: Array<{
-    id: string
-    productId: string
-    productTitle: string | null
-    productSlug: string | null
-    productSku: string | null
-    quantity: number
-    unitPrice: string
-    lineTotal: string
-  }>
-}
+    id: string;
+    productId: string;
+    productTitle: string | null;
+    productSlug: string | null;
+    productSku: string | null;
+    quantity: number;
+    unitPrice: string;
+    lineTotal: string;
+  }>;
+};
 
 function toOrderItem(
-  item:
-    | {
-        id: string | null
-        productId: string | null
-        productTitle: string | null
-        productSlug: string | null
-        productSku: string | null
-        quantity: number | null
-        unitPrice: string | null
-        lineTotal: string | null
-      }
-    | null
-): OrderDetailResponse["items"][number] | null {
-  if (!item || !item.id) return null
+  item: {
+    id: string | null;
+    productId: string | null;
+    productTitle: string | null;
+    productSlug: string | null;
+    productSku: string | null;
+    quantity: number | null;
+    unitPrice: string | null;
+    lineTotal: string | null;
+  } | null
+): OrderDetailResponse['items'][number] | null {
+  if (!item || !item.id) return null;
 
-  if (!item.productId || item.quantity === null || !item.unitPrice || !item.lineTotal) {
-    throw new Error("Corrupt order item row: required columns are null")
+  if (
+    !item.productId ||
+    item.quantity === null ||
+    !item.unitPrice ||
+    !item.lineTotal
+  ) {
+    throw new Error('Corrupt order item row: required columns are null');
   }
 
   return {
@@ -71,22 +79,36 @@ function toOrderItem(
     quantity: item.quantity,
     unitPrice: item.unitPrice,
     lineTotal: item.lineTotal,
-  }
+  };
 }
 
-
-export async function GET(_request: NextRequest, context: { params: Promise<{ id: string }> }) {
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
   try {
-    const user = await getCurrentUser()
+    const user = await getCurrentUser();
     if (!user) {
-      return noStoreJson({ code: "UNAUTHORIZED", error: "Authentication required" }, { status: 401 })
+      return noStoreJson(
+        { code: 'UNAUTHORIZED', error: 'Authentication required' },
+        { status: 401 }
+      );
     }
 
-    const rawParams = await context.params
-    const parsed = orderIdParamSchema.safeParse(rawParams)
+    const rawParams = await context.params;
+    const parsed = orderIdParamSchema.safeParse(rawParams);
     if (!parsed.success) {
-      return noStoreJson({ code: "INVALID_ORDER_ID", error: "Invalid order id" }, { status: 400 })
+      return noStoreJson(
+        { code: 'INVALID_ORDER_ID', error: 'Invalid order id' },
+        { status: 400 }
+      );
     }
+
+    const isAdmin = user.role === 'admin';
+
+    const whereClause = isAdmin
+      ? eq(orders.id, parsed.data.id)
+      : and(eq(orders.id, parsed.data.id), eq(orders.userId, user.id));
 
     const rows = await db
       .select({
@@ -117,26 +139,18 @@ export async function GET(_request: NextRequest, context: { params: Promise<{ id
       })
       .from(orders)
       .leftJoin(orderItems, eq(orderItems.orderId, orders.id))
-      .where(eq(orders.id, parsed.data.id))
+      .where(whereClause)
+
 
     if (rows.length === 0) {
-      return noStoreJson({ code: "ORDER_NOT_FOUND" }, { status: 404 })
+      return noStoreJson({ code: 'ORDER_NOT_FOUND' }, { status: 404 });
     }
 
-    const base = rows[0]!.order
-
-    // Authorization: admin OR owner
-    const isAdmin = user.role === "admin"
-    const isOwner = base.userId !== null && base.userId === user.id
-
-    // Security: do not leak existence -> 404 for “not yours”
-    if (!isAdmin && !isOwner) {
-      return noStoreJson({ code: "ORDER_NOT_FOUND" }, { status: 404 })
-    }
+    const base = rows[0]!.order;
 
     const items = rows
       .map(r => toOrderItem(r.item))
-      .filter((i): i is NonNullable<typeof i> => i !== null)
+      .filter((i): i is NonNullable<typeof i> => i !== null);
 
     const response: OrderDetailResponse = {
       ...base,
@@ -144,11 +158,14 @@ export async function GET(_request: NextRequest, context: { params: Promise<{ id
       updatedAt: base.updatedAt.toISOString(),
       restockedAt: base.restockedAt ? base.restockedAt.toISOString() : null,
       items,
-    }
+    };
 
-    return noStoreJson({ success: true, order: response }, { status: 200 })
+    return noStoreJson({ success: true, order: response }, { status: 200 });
   } catch (error) {
-    logError("Public order detail failed", error)
-    return noStoreJson({ code: "INTERNAL_ERROR", error: "internal_error" }, { status: 500 })
+    logError('Public order detail failed', error);
+    return noStoreJson(
+      { code: 'INTERNAL_ERROR', error: 'internal_error' },
+      { status: 500 }
+    );
   }
 }

--- a/frontend/lib/validation/shop.ts
+++ b/frontend/lib/validation/shop.ts
@@ -205,24 +205,47 @@ export const productAdminUpdateSchema = z
     }
   })
 
-export const checkoutItemSchema = z.object({
-  productId: z.string().uuid(),
-  quantity: z.number().int().min(1).max(MAX_QUANTITY_PER_LINE),
-  selectedSize: z.string().optional(),
-  selectedColor: z.string().optional(),
-})
+export const checkoutItemSchema = z
+  .object({
+    productId: z.string().uuid(),
+    quantity: z.coerce.number().int().min(1).max(MAX_QUANTITY_PER_LINE),
+    selectedSize: z.string().optional(),
+    selectedColor: z.string().optional(),
+  })
+  .strict()
 
-export const checkoutPayloadSchema = z.object({
-  items: z.array(checkoutItemSchema).min(1),
-  userId: z.string().uuid().optional(),
-})
+export const checkoutPayloadSchema = z
+  .object({
+    items: z.array(checkoutItemSchema).min(1),
+    userId: z.string().uuid().optional(),
+  })
+  .strict()
+
+export const cartRehydratePayloadSchema = z
+  .object({
+    items: z
+      .array(
+        z
+          .object({
+            productId: z.string().uuid(),
+            quantity: z.coerce.number().int().min(1).max(MAX_QUANTITY_PER_LINE),
+            selectedSize: z.string().optional(),
+            selectedColor: z.string().optional(),
+          })
+          .strict(),
+      )
+      .min(1),
+  })
+  .strict()
+
 
 export const idempotencyKeySchema = z
   .string()
   .trim()
-  .min(16) // було min(1)
+  .min(16)
   .max(128)
-  .regex(/^[A-Za-z0-9_\-]+$/)
+  .regex(/^[A-Za-z0-9_.-]+$/)
+
 
 
 export const cartClientItemSchema = z.object({
@@ -230,19 +253,6 @@ export const cartClientItemSchema = z.object({
   quantity: z.coerce.number().int().min(1).max(MAX_QUANTITY_PER_LINE),
   selectedSize: z.string().optional(),
   selectedColor: z.string().optional(),
-})
-
-export const cartRehydratePayloadSchema = z.object({
-  items: z
-    .array(
-      z.object({
-        productId: z.string().uuid(),
-        quantity: z.number().int().min(1).max(MAX_QUANTITY_PER_LINE),
-        selectedSize: z.string().optional(),
-        selectedColor: z.string().optional(),
-      }),
-    )
-    .min(1),
 })
 
 export const cartRehydratedItemSchema = z.object({

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -58,5 +58,5 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/', '/(uk|en|pl)/:path*', '/((?!api|_next|.*\\..*).*)', "/api/shop/admin/:path*",],
+  matcher: ['/', '/(uk|en|pl)/:path*', '/((?!api|_next|.*\\..*).*)',],
 };

--- a/frontend/project-structure.txt
+++ b/frontend/project-structure.txt
@@ -4,38 +4,150 @@
 📁 actions
   📄 quiz.ts
 📁 app
-  📁 about
-    📄 page.tsx
   📁 api
+    📁 auth
+      📁 login
+        📄 route.ts
+      📁 logout
+        📄 route.ts
+      📁 me
+        📄 route.ts
+      📁 signup
+        📄 route.ts
     📁 questions
       📁 [category]
         📄 route.ts
     📁 quiz
       📁 [slug]
         📄 route.ts
-  📁 contacts
-    📄 page.tsx
+    📁 shop
+      📁 admin
+        📁 orders
+          📁 reconcile-stale
+            📄 route.ts
+          📄 route.ts
+          📁 [id]
+            📁 refund
+              📄 route.ts
+            📄 route.ts
+        📁 products
+          📄 route.ts
+          📁 [id]
+            📄 route.ts
+            📁 status
+              📄 route.ts
+      📁 cart
+        📁 rehydrate
+          📄 route.ts
+      📁 checkout
+        📄 route.ts
+      📁 internal
+        📁 orders
+          📁 restock-stale
+            📄 route.ts
+      📁 orders
+        📁 [id]
+          📄 route.ts
+      📁 webhooks
+        📁 stripe
+          📄 route.ts
   📄 favicon.ico
   📄 globals.css
   📄 layout.tsx
-  📁 leaderboard
+  📁 [locale]
+    📁 about
+      📄 page.tsx
+    📁 blog
+      📄 page.tsx
+      📁 [slug]
+        📄 page.tsx
+        📄 PostDetails.tsx
+    📁 contacts
+      📄 page.tsx
+    📁 dashboard
+      📄 page.tsx
+    📄 layout.tsx
+    📁 leaderboard
+      📄 page.tsx
+    📁 login
+      📄 page.tsx
+    📄 not-found.tsx
     📄 page.tsx
-  📄 not-found.tsx
-  📄 page.tsx
-  📁 post
-    📄 page.tsx
-  📁 q&a
-    📄 page.tsx
-  📁 quiz
-    📁 [slug]
+    📁 privacy-policy
+      📄 page.tsx
+    📁 q&a
+      📄 page.tsx
+    📁 quiz
+      📁 [slug]
+        📄 page.tsx
+    📁 shop
+      📁 admin
+        📄 layout.tsx
+        📁 orders
+          📄 page.tsx
+          📁 [id]
+            📄 page.tsx
+        📄 page.tsx
+        📁 products
+          📁 new
+            📄 page.tsx
+          📄 page.tsx
+          📁 [id]
+            📁 edit
+              📄 page.tsx
+          📁 _components
+            📄 product-form.tsx
+      📁 cart
+        📄 page.tsx
+      📁 checkout
+        📁 error
+          📄 page.tsx
+        📁 payment
+          📄 StripePaymentClient.tsx
+          📁 [orderId]
+            📄 page.tsx
+        📁 success
+          📄 page.tsx
+      📄 layout.tsx
+      📄 page.tsx
+      📁 products
+        📄 page.tsx
+        📁 [slug]
+          📄 page.tsx
+      📄 shop-theme.css
+    📁 signup
+      📄 page.tsx
+    📁 terms-of-service
       📄 page.tsx
 📄 client.ts
 📁 components
+  📁 about
+    📄 CommunitySection.tsx
+    📄 FeaturesSection.tsx
+    📄 HeroSection.tsx
+    📄 PricingSection.tsx
+    📄 StatsSection.tsx
+  📁 auth
+    📄 logoutButton.tsx
+  📁 blog
+    📄 AuthorModal.tsx
+    📄 BlogCard.tsx
+    📄 BlogFilters.tsx
+    📄 BlogGrid.tsx
+  📁 dashboard
+    📄 ProfileCard.tsx
+    📄 StatsCard.tsx
   📁 leaderboard
+    📄 LeaderboardClient.tsx
     📄 LeaderboardPodium.tsx
     📄 LeaderboardTable.tsx
     📄 LeaderboardTabs.tsx
     📄 types.ts
+  📁 legal
+    📄 LegalBlock.tsx
+    📄 LegalPageShell.tsx
+    📄 PrivacyPolicyContent.tsx
+    📄 TermsOfServiceContent.tsx
   📁 quiz
     📄 ExplanationRenderer.tsx
     📄 QuizContainer.tsx
@@ -44,8 +156,30 @@
     📄 QuizResult.tsx
   📁 shared
     📄 AccordionList.tsx
+    📄 Footer.tsx
     📄 HeroSection.tsx
+    📄 LanguageSwitcher.tsx
+    📄 Pagination.tsx
     📄 TabsSection.tsx
+  📁 shop
+    📄 add-to-cart-button.tsx
+    📁 admin
+      📄 admin-product-status-toggle.tsx
+    📄 cart-provider.tsx
+    📄 catalog-load-more.tsx
+    📄 category-tile.tsx
+    📁 header
+      📄 cart-button.tsx
+      📄 mobile-nav.tsx
+      📄 nav-links.tsx
+      📄 theme-toggle.tsx
+    📄 product-card.tsx
+    📄 product-filters.tsx
+    📄 product-sort.tsx
+    📄 shop-footer.tsx
+    📄 shop-header.tsx
+    📄 shop-hero.tsx
+    📄 theme-provider.tsx
   📁 theme
     📄 ThemeProvider.tsx
     📄 ThemeToggle.tsx
@@ -56,38 +190,96 @@
     📄 tabs.tsx
 📄 components.json
 📁 data
+  📄 parse.ts
   📄 questions.json
+  📄 README.md
 📁 db
   📄 index.ts
   📁 queries
+    📄 leaderboard.ts
+    📄 points.ts
     📄 quiz.ts
+    📁 shop
+      📄 admin-orders.ts
+      📄 orders.ts
+      📄 products.ts
+    📄 users.ts
   📁 schema
     📄 categories.ts
     📄 index.ts
+    📄 points.ts
     📄 quiz.ts
+    📄 shop.ts
+    📄 users.ts
+  📄 seed-categories.ts
+  📄 seed-demo-leaderboard.ts
   📄 seed-quiz-react.ts
+  📄 seed-users.ts
   📄 seed.ts
-  📄 seedCategories.ts
   📄 verify-quiz-seed.ts
-📁 db_script
-  📁 data
-  📄 README.md
-  📄 script.ts
 📁 drizzle
-  📄 0000_strong_mauler.sql
-  📄 0001_tiny_kitty_pryde.sql
-  📄 0002_fantastic_retro_girl.sql
+  📄 0000_fair_quasar.sql
+  📄 0000_moaning_reavers.sql
+  📄 0000_rich_magus.sql
+  📄 0001_black_random.sql
+  📄 0002_yielding_purple_man.sql
+  📄 0003_handy_cammi.sql
   📁 meta
     📄 0000_snapshot.json
     📄 0001_snapshot.json
     📄 0002_snapshot.json
+    📄 0003_snapshot.json
     📄 _journal.json
+  📄 relations.ts
+  📄 schema.ts
 📄 drizzle.config.ts
 📄 eslint.config.mjs
 📁 hooks
+  📄 use-mounted.ts
   📄 useAntiCheat.ts
+📁 i18n
+  📄 config.ts
+  📄 request.ts
+  📄 routing.ts
 📁 lib
+  📁 admin
+    📄 parseAdminProductForm.ts
+  📁 auth
+    📄 admin.ts
+  📄 auth.ts
+  📄 cart.ts
+  📄 cloudinary.ts
+  📁 config
+    📄 catalog.ts
+  📁 env
+    📄 cloudinary.ts
+    📄 index.ts
+    📄 stripe.ts
+  📄 logging.ts
+  📄 logout.ts
+  📁 psp
+    📄 stripe.ts
+  📁 services
+    📄 errors.ts
+    📄 orders.ts
+    📄 products.ts
+  📁 shop
+    📄 currency.ts
+    📄 data.ts
+    📄 idempotency.ts
+    📄 money.ts
+    📄 slug.ts
+  📁 types
+    📄 shop.ts
   📄 utils.ts
+  📁 validation
+    📄 checkout.ts
+    📄 shop.ts
+📁 messages
+  📄 en.json
+  📄 pl.json
+  📄 uk.json
+📄 middleware.ts
 📄 next-env.d.ts
 📄 next.config.ts
 📄 package-lock.json
@@ -96,6 +288,8 @@
 📄 project-structure.txt
 📁 public
   📄 github-logo.svg
+  📄 placeholder.svg
 📄 README.md
 📄 save-structure.cjs
 📄 tsconfig.json
+📄 tsconfig.tsbuildinfo

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -28,7 +34,10 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
+    ".next/dev/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. Focus on WHAT was changed and WHY. -->

This PR closes multiple production blockers around deployment stability, order privacy, admin API safety, and checkout invariants.

Key outcomes:
- Deploy previews no longer fail due to missing Cloudinary environment variables.
- `/api/shop/orders/[id]` is no longer enumerable: only the order owner or an admin can access it (others get `404` to hide existence).
- Admin mutating endpoints are protected by a production kill-switch (`ENABLE_ADMIN_API`) with a stable error contract.
- When payments are disabled, checkout creates orders in a consistent final state (`paymentProvider=none`, `paymentStatus=paid`, PSP fields null) and the API response mirrors the service state.


## Changes

- **Repo / Deploy Stability (0.1)**
  - Added Cloudinary env vars to Netlify Deploy Previews (`CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`) to prevent preview build failures.
  - Updated `.env.example` with minimal Cloudinary entries + comments.
  - Added/updated `docs/env.md` with a clear Cloudinary section.

- **Security: Orders privacy (P0-SEC-1.1)**
  - Hardened `app/api/shop/orders/[id]/route.ts` to require auth and enforce ownership/admin access.
  - Implemented “hide existence” policy: no session → `401`; authenticated but not owner/admin → `404`.

- **Admin API kill-switch coverage (P0-7 / P0-7.1)**
  - Implemented `assertAdminApiEnabled()` (stable code/message) in `lib/auth/admin.ts`.
  - Added kill-switch enforcement to all admin mutating endpoints (`app/api/**/admin/**/route.ts`, including `app/api/shop/admin/**`).
  - Documented `ENABLE_ADMIN_API` in `.env.example` and `docs/env.md` with guidance for production usage.

- **Checkout consistency without Stripe (P0-8 / P0-8.1)**
  - Enforced service invariant in `lib/services/orders.ts`: when payments are disabled, new orders are created as `paid/none` with PSP fields null.
  - Updated `app/api/shop/checkout/route.ts` to mirror the service state and avoid “patching” payment fields in the route handler.

---

## Database Changes (if applicable)

<!-- Check all that apply -->

- [ ] Schema migration required
- [ ] Seed data updated
- [ ] Breaking changes to existing queries
- [ ] Transaction-safe migration
- [ ] Migration tested locally on Neon

---

## How Has This Been Tested?

<!-- Describe how you tested the changes -->

- [x] Tested locally
- [x] Verified in development environment
- [ ] Checked responsive layout (if UI-related)
- [ ] Tested accessibility (keyboard / screen reader)

Evidence / checks performed:

- **0.1 Deploy preview / build**
  - Netlify Deploy Preview builds successfully after Cloudinary env vars are present.
  - `npm run build` passes locally.

- **P0-SEC-1.1 Orders access control**
  - `401` when no auth cookie is provided.
  - `404` when authenticated as another user (non-owner, non-admin).
  - `200` for the order owner.
  - `200` for admin.

- **P0-7.1 Admin kill-switch**
  - Simulated `NODE_ENV=production` with `ENABLE_ADMIN_API` missing/false → admin mutating endpoints return `403` with `ADMIN_API_DISABLED`.

- **P0-8.1 Payments disabled checkout invariants**
  - Checkout creates an order where:
    - `paymentProvider=none`
    - `paymentStatus=paid`
    - `paymentIntentId=null`
    - `clientSecret=null`
  - Verified both API response and DB row match.
  - Verified idempotency retry (`Idempotency-Key`) returns `200` and the same `orderId`.

---

## Screenshots (if applicable)

<!-- Add screenshots or recordings for UI changes -->

N/A (no UI changes)

---

## Checklist

### Before submitting

- [x] Code has been self-reviewed
- [x] No TypeScript or console errors
- [x] Code follows project conventions
- [x] Scope is limited to this feature/fix
- [x] No unrelated refactors included
- [x] English used in code, commits, and docs
- [x] New dependencies discussed with team
- [ ] Database migration tested locally (if applicable)
- [ ] GitHub Projects card moved to **In Review**

---

## Reviewers

<!-- Assign one of the required reviewers -->

- [ ] @ViktorSvertoka
- [ ] @AndrewMotko
