### PR TITLE
fix(auth): allow unauthenticated access to quiz and leaderboard pages

### DIFF
--- a/frontend/lib/navigation.ts
+++ b/frontend/lib/navigation.ts
@@ -1,6 +1,6 @@
 export const SITE_LINKS = [
   { href: '/q&a', label: 'Q&A' },
-  { href: '/quiz/react-fundamentals', label: 'Quiz' },
+  { href: '/quizzes', label: 'Quizzes' },
   { href: '/leaderboard', label: 'Leaderboard' },
   { href: '/blog', label: 'Blog' },
   { href: '/about', label: 'About' },

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -31,16 +31,12 @@ function authMiddleware(req: NextRequest) {
     return NextResponse.redirect(new URL(`/${locale}/`, req.url));
   }
 
-  if (
-    pathnameWithoutLocale.startsWith('/leaderboard') ||
-    pathnameWithoutLocale.startsWith('/quiz') ||
-    pathnameWithoutLocale.startsWith('/dashboard')
-  ) {
-    if (!authenticated) {
-      const locale = pathname.split('/')[1] || 'uk';
-      return NextResponse.redirect(new URL(`/${locale}/login`, req.url));
-    }
+  if (pathnameWithoutLocale.startsWith('/dashboard')) {
+  if (!authenticated) {
+    const locale = pathname.split('/')[1] || 'uk';
+    return NextResponse.redirect(new URL(`/${locale}/login`, req.url));
   }
+}
 
   return null;
 }


### PR DESCRIPTION
- Remove auth guard from /quiz and /leaderboard routes (guest flow support)
- Update header navigation to point to /quizzes list instead of specific quiz
- Keep /dashboard protected as it contains user-specific data"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated Quiz navigation link to point to the new Quizzes page.
  * Adjusted authentication requirements—Leaderboard and Quiz sections are now accessible without authentication; Dashboard remains login-protected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->