### PR TITLE
feat(ci): notify Telegram when a pull request is opened

### DIFF
--- a/.github/workflows/telegram-pr-opened.yml
+++ b/.github/workflows/telegram-pr-opened.yml
@@ -1,0 +1,25 @@
+name: Telegram — PR opened
+
+on:
+    pull_request:
+        types: [opened]
+
+jobs:
+    notify:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Send Telegram message
+              uses: appleboy/telegram-action@v1.0.1
+              with:
+                  token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+                  to: ${{ secrets.TELEGRAM_CHAT_ID }}
+                  message: |
+                      🚀 New Pull Request created!
+
+                      📦 Repository: ${{ github.repository }}
+                      👤 Author: ${{ github.actor }}
+                      📝 Title: ${{ github.event.pull_request.title }}
+                      🌿 Branches: ${{ github.head_ref }} → ${{ github.base_ref }}
+
+                      🔗 Open PR:
+                      ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Telegram notifications for Pull Requests

### What was done
- Added GitHub Actions workflow to send a Telegram notification when a Pull Request is created.
- Integrated Telegram Bot API using repository secrets.
- Notifications are sent automatically to the DevLovers Team chat.

### How it works
- On `pull_request: opened` event, GitHub Actions triggers a workflow.
- The workflow sends a message to the Telegram group with:
  - repository name
  - PR author
  - PR title
  - source and target branches
  - direct link to the PR

### Why
This improves team visibility and communication by instantly notifying the team about new Pull Requests without needing to check GitHub manually.

### How to test
1. Create a new branch.
2. Open a Pull Request.
3. Verify that a notification appears in the DevLovers Team Telegram chat.

### Notes
- Secrets `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` are configured at the repository level.
- No changes to existing CI or branch protection rules were required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development workflow automation with improved pull request notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->