### PR TITLE
Fix Netlify build by skipping product static params generation

### DIFF
--- a/frontend/app/[locale]/shop/products/[slug]/page.tsx
+++ b/frontend/app/[locale]/shop/products/[slug]/page.tsx
@@ -12,7 +12,15 @@ import { formatMoney } from "@/lib/shop/currency";
 import { Link } from "@/i18n/routing";
 import { locales } from "@/i18n/config";
 
+const shouldSkipStaticParams =
+  process.env.NETLIFY === "true" ||
+  process.env.SKIP_BUILD_STATIC_PARAMS === "true";
+
 export async function generateStaticParams() {
+  if (shouldSkipStaticParams) {
+    return [];
+  }
+
   const all: { locale: string; slug: string }[] = [];
 
   for (const locale of locales) {


### PR DESCRIPTION
## Summary
- skip `generateStaticParams` for product pages when running on Netlify
- avoid build-time DB calls that were failing with DNS resolution errors

## Why
Netlify builds were failing because Next.js attempted to query Neon during static params generation, and DNS lookups (`EAI_AGAIN`) failed in CI.

## How to test
- trigger a Netlify build for `main`
- verify the build completes successfully
- open a product page to confirm it renders as expected
