### PR TITLE
Remove Redis TTL for static quiz and QA caches

### DIFF
--- a/frontend/components/q&a/AIWordHelper.tsx
+++ b/frontend/components/q&a/AIWordHelper.tsx
@@ -303,7 +303,6 @@ export default function AIWordHelper({
 
     if (isOpen) {
       document.addEventListener('keydown', handleKeyDown);
-      // Calculate scrollbar width and add padding to prevent layout shift
       const scrollbarWidth =
         window.innerWidth - document.documentElement.clientWidth;
       document.body.style.overflow = 'hidden';
@@ -582,14 +581,12 @@ export default function AIWordHelper({
                             )}
                           </button>
 
-                          {/* Activity suggestions while waiting */}
                           <div className="mt-4 w-full border-t border-gray-200 pt-4 dark:border-neutral-700">
                             <p className="mb-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400">
                               {messages.rateLimit.whileWaiting}
                             </p>
 
                             {rateLimitState.retryAttempts < 3 ? (
-                              // First suggestions: Take Quiz & Star GitHub
                               <div className="flex flex-col gap-2">
                                 <Link
                                   href="/quizzes"
@@ -640,7 +637,6 @@ export default function AIWordHelper({
                                 </a>
                               </div>
                             ) : (
-                              // After 3+ attempts: Sponsor & Review
                               <div className="flex flex-col gap-2">
                                 <a
                                   href="https://github.com/sponsors/DevLoversTeam"

--- a/frontend/components/q&a/SelectableText.tsx
+++ b/frontend/components/q&a/SelectableText.tsx
@@ -19,7 +19,6 @@ export default function SelectableText({
   const onTextSelectRef = useRef(onTextSelect);
   const onSelectionClearRef = useRef(onSelectionClear);
 
-  // Keep refs updated with latest callbacks
   useEffect(() => {
     onTextSelectRef.current = onTextSelect;
     onSelectionClearRef.current = onSelectionClear;

--- a/frontend/lib/cache/qa.ts
+++ b/frontend/lib/cache/qa.ts
@@ -1,7 +1,5 @@
 import { getRedisClient } from '@/lib/redis';
 
-const QA_CACHE_TTL_SECONDS = 60 * 60 * 12;
-
 type QaCacheKeyInput = {
   category: string;
   locale: string;
@@ -48,7 +46,7 @@ export async function setQaCache<T>(key: string, value: T) {
   const redis = getRedisClient();
   if (!redis) return;
 
-  await redis.set(key, value, { ex: QA_CACHE_TTL_SECONDS });
+  await redis.set(key, value);
 }
 
 export async function invalidateQaCacheByCategory(category: string) {
@@ -97,7 +95,3 @@ export async function invalidateAllQaCache() {
 
   return deleted;
 }
-
-export const qaCacheConfig = {
-  ttlSeconds: QA_CACHE_TTL_SECONDS,
-};

--- a/frontend/lib/quiz/quiz-answers-redis.ts
+++ b/frontend/lib/quiz/quiz-answers-redis.ts
@@ -4,11 +4,9 @@ import { db } from '@/db';
 import { quizAnswers, quizQuestions } from '@/db/schema/quiz';
 import { getRedisClient } from '@/lib/redis';
 
-const QUIZ_CACHE_TTL_SECONDS = 60 * 60 * 12;
-
 interface QuizAnswersCache {
   quizId: string;
-  answers: Record<string, string>; // questionId - correctAnswerId
+  answers: Record<string, string>;
   cachedAt: number;
 }
 
@@ -22,18 +20,16 @@ export async function getOrCreateQuizAnswersCache(
   const redis = getRedisClient();
   if (!redis) {
     console.warn('Redis not configured, skipping cache');
-    return true; // Allow quiz to proceed without cache
+    return true;
   }
 
   const key = getCacheKey(quizId);
 
-  // Check if cache exists
   const existing = await redis.get<QuizAnswersCache>(key);
   if (existing) {
-    return true; // Cache hit
+    return true;
   }
 
-  // Fetch correct answers from DB
   const correctAnswers = await db
     .select({
       questionId: quizQuestions.id,
@@ -60,7 +56,7 @@ export async function getOrCreateQuizAnswersCache(
     cachedAt: Date.now(),
   };
 
-  await redis.set(key, cacheData, { ex: QUIZ_CACHE_TTL_SECONDS });
+  await redis.set(key, cacheData);
   return true;
 }
 
@@ -69,7 +65,7 @@ export async function getCorrectAnswer(
   questionId: string
 ): Promise<string | null> {
   const redis = getRedisClient();
-  
+
   if (redis) {
     const key = getCacheKey(quizId);
     const cache = await redis.get<QuizAnswersCache>(key);
@@ -78,7 +74,6 @@ export async function getCorrectAnswer(
     }
   }
 
-  // DB fallback when Redis unavailable or cache miss
   const result = await db
     .select({ answerId: quizAnswers.id })
     .from(quizAnswers)
@@ -94,4 +89,3 @@ export async function getCorrectAnswer(
 
   return result[0]?.answerId ?? null;
 }
-

--- a/frontend/lib/quiz/quiz-session.ts
+++ b/frontend/lib/quiz/quiz-session.ts
@@ -1,5 +1,5 @@
 const STORAGE_KEY_PREFIX = 'quiz_session_';
-const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const SESSION_TTL_MS = 30 * 60 * 1000;
 
 export interface QuizSessionData {
   status: 'rules' | 'in_progress' | 'completed';
@@ -39,13 +39,11 @@ export function loadQuizSession(quizId: string): QuizSessionData | null {
 
     const data: QuizSessionData = JSON.parse(raw);
 
-    // Discard sessions older than 30 minutes
     if (Date.now() - data.savedAt > SESSION_TTL_MS) {
       clearQuizSession(quizId);
       return null;
     }
 
-    // Only restore in_progress sessions
     if (data.status === 'rules') {
       clearQuizSession(quizId);
       return null;


### PR DESCRIPTION
- Remove TTL configuration for quiz answers cache.
- Store QA cache entries without expiration.
- Keep Redis reads as the primary source for static data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up inline comments across Q&A and quiz components for improved code maintainability.
  * Removed cache time-to-live (TTL) configuration, allowing cached data to persist without automatic expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->