### PR TITLE
 fix(layout): remove duplicate padding from quiz routes

### DIFF
--- a/frontend/app/[locale]/q&a/page.tsx
+++ b/frontend/app/[locale]/q&a/page.tsx
@@ -30,7 +30,7 @@ export default async function QAPage({
     <DynamicGridBackground className="bg-gray-50 py-10 transition-colors duration-300 dark:bg-transparent">
       <main className="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="mb-8">
-          <p className="text-sm font-semibold text-[var(--accent-primary)]">
+          <p className="text-sm font-semibold text-(--accent-primary)">
             {t('pretitle')}
           </p>
           <h1 className="text-3xl font-bold">{t('title')}</h1>

--- a/frontend/app/[locale]/quizzes/page.tsx
+++ b/frontend/app/[locale]/quizzes/page.tsx
@@ -36,7 +36,7 @@ export default async function QuizzesPage({ params }: PageProps) {
     <DynamicGridBackground className="min-h-screen bg-gray-50 py-10 transition-colors duration-300 dark:bg-transparent">
       <main className="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="mb-8">
-          <p className="text-sm font-semibold text-[var(--accent-primary)]">
+          <p className="text-sm font-semibold text-(--accent-primary)">
             {t('practice')}
           </p>
           <h1 className="text-3xl font-bold">{t('title')}</h1>

--- a/frontend/components/header/MainSwitcher.tsx
+++ b/frontend/components/header/MainSwitcher.tsx
@@ -28,6 +28,12 @@ function isHomePath(pathname: string): boolean {
   );
 }
 
+function isQuizzesPath(pathname: string): boolean {
+  const segments = pathname.split('/').filter(Boolean);
+  return segments[0] === 'quizzes' || segments[1] === 'quizzes' ||
+         segments[0] === 'quiz' || segments[1] === 'quiz';
+}
+
 type MainSwitcherProps = {
   children: ReactNode;
   userExists: boolean;
@@ -64,7 +70,7 @@ export function MainSwitcher({
   }
 
   return (
-    <main className={isQa || isHome ? 'mx-auto' : 'mx-auto min-h-[80vh] px-6'}>
+    <main className={isQa || isHome || isQuizzesPath(pathname) ? 'mx-auto' : 'mx-auto min-h-[80vh] px-6'}>
       {children}
     </main>
   );


### PR DESCRIPTION
## Summary

- Add isQuizzesPath helper to exclude quiz routes from MainSwitcher padding
- Fix mobile layout misalignment on quiz pages (Quiz Rules card now aligns with title)