### PR TITLE
(SP: 1) [Frontend] Fix Q&A mobile tap lock, pagination scroll, and table text contrast

### DIFF
--- a/frontend/components/q&a/AccordionList.tsx
+++ b/frontend/components/q&a/AccordionList.tsx
@@ -244,7 +244,7 @@ function renderTable(
 ): ReactNode {
   return (
     <div key={index} className="my-2 overflow-x-auto">
-      <table className="min-w-full border-collapse border border-gray-300 text-sm">
+      <table className="min-w-full border-collapse border border-gray-300 text-sm text-gray-900 dark:text-gray-900">
         <thead>
           <tr className="bg-gray-100">
             {block.header.map((cell, i) => (
@@ -363,6 +363,14 @@ export default function AccordionList({ items }: { items: QuestionEntry[] }) {
     onTermClick: handleCachedTermClick,
   };
 
+  const clearSelection = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const selection = window.getSelection?.();
+    if (selection && !selection.isCollapsed) {
+      selection.removeAllRanges();
+    }
+  }, []);
+
   return (
     <>
       <Accordion type="single" collapsible className="w-full">
@@ -382,7 +390,10 @@ export default function AccordionList({ items }: { items: QuestionEntry[] }) {
                   : undefined
               }
             >
-              <AccordionTrigger className="px-4 hover:no-underline">
+              <AccordionTrigger
+                className="px-4 hover:no-underline"
+                onPointerDown={clearSelection}
+              >
                 {q.question}
               </AccordionTrigger>
               <AccordionContent className="px-4">

--- a/frontend/components/q&a/useQaTabs.ts
+++ b/frontend/components/q&a/useQaTabs.ts
@@ -131,7 +131,6 @@ export function useQaTabs() {
     (page: number) => {
       setCurrentPage(page);
       updateUrl(active, page);
-      window.scrollTo({ top: 0, behavior: 'smooth' });
     },
     [active, updateUrl]
   );

--- a/frontend/components/tests/q&a/use-qa-tabs.test.tsx
+++ b/frontend/components/tests/q&a/use-qa-tabs.test.tsx
@@ -44,7 +44,6 @@ describe('useQaTabs', () => {
       }),
     });
     vi.stubGlobal('fetch', fetchMock);
-    vi.stubGlobal('scrollTo', vi.fn());
     routerReplace.mockClear();
     searchParamsValue = new URLSearchParams();
   });
@@ -85,7 +84,6 @@ describe('useQaTabs', () => {
     expect(routerReplace).toHaveBeenCalledWith('/q&a?page=2', {
       scroll: false,
     });
-    expect(window.scrollTo).toHaveBeenCalled();
   });
 
   it('updates category and URL on category change', async () => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9721,17 +9721,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
-      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",


### PR DESCRIPTION
## Summary
- Move Q&A pagination scroll to the section level for consistent top-of-list behavior.
- Prevent mobile tap “lock” by clearing text selection before accordion/pagination interactions.
- Keep Q&A table text readable in dark mode by fixing table text color.

## Changes
- `frontend/components/q&a/QaSection.tsx`
- `frontend/components/q&a/AccordionList.tsx`
- `frontend/components/tests/q&a/use-qa-tabs.test.tsx`

## Testing
- Not run (UI change).

## Notes
- Focused on mobile tap responsiveness after multiple accordion opens.

Closes: #275 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Text selection is now automatically cleared when expanding accordion items for a smoother user experience.
  * Pagination scroll behavior refined to smoothly animate to the Q&A section instead of scrolling to the page top.

* **Style**
  * Adjusted text color styling on table elements for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->