### PR TITLE
(SP: 3) [SHOP] CP-01 commercial policy refactor: decouple locale, enforce UAH storefront, align checkout, and admin pricing cleanup

### DIFF
--- a/frontend/app/[locale]/admin/shop/products/_components/ProductForm.tsx
+++ b/frontend/app/[locale]/admin/shop/products/_components/ProductForm.tsx
@@ -580,6 +580,11 @@ export function ProductForm({
         p => p.price.length > 0 || p.originalPrice.length > 0
       );
 
+      if (effectivePrices.length === 0) {
+        setError('At least one price is required.');
+        return;
+      }
+
       for (const p of effectivePrices) {
         if (!p.price.length && p.originalPrice.length) {
           setError(
@@ -587,12 +592,6 @@ export function ProductForm({
           );
           return;
         }
-      }
-
-      const usd = effectivePrices.find(p => p.currency === 'USD');
-      if (!usd || !usd.price.length) {
-        setError('USD price is required.');
-        return;
       }
 
       let minorPrices: Array<{
@@ -838,67 +837,15 @@ export function ProductForm({
             Prices
           </legend>
 
+          <p className="text-muted-foreground mt-2 text-xs">
+            UAH is the standard storefront price. USD is optional and kept only
+            as a compatibility price.
+          </p>
+
           <div className="mt-3 grid gap-4 sm:grid-cols-2">
             <fieldset className="space-y-2">
               <legend className="text-muted-foreground text-xs font-medium">
-                USD (required)
-              </legend>
-
-              <div>
-                <label className={LABEL_CLASS} htmlFor="price-usd">
-                  Price (USD)
-                </label>
-                <input
-                  id="price-usd"
-                  name="price-usd"
-                  className={INPUT_CLASS}
-                  type="text"
-                  inputMode="decimal"
-                  placeholder="59.00"
-                  value={usdRow?.price ?? ''}
-                  onChange={e => setPriceField('USD', 'price', e.target.value)}
-                  required
-                />
-              </div>
-
-              <div>
-                <label className={LABEL_CLASS} htmlFor="original-usd">
-                  Original price (USD)
-                </label>
-                <input
-                  id="original-usd"
-                  name="original-usd"
-                  className={cn(
-                    INPUT_CLASS,
-                    usdOriginalError && 'border-red-500'
-                  )}
-                  type="text"
-                  inputMode="decimal"
-                  placeholder="79.00"
-                  value={usdRow?.originalPrice ?? ''}
-                  onChange={e =>
-                    setPriceField('USD', 'originalPrice', e.target.value)
-                  }
-                  aria-invalid={usdOriginalError ? true : undefined}
-                  aria-describedby={
-                    usdOriginalError ? usdOriginalErrorId : undefined
-                  }
-                />
-                {usdOriginalError ? (
-                  <p
-                    id={usdOriginalErrorId}
-                    className="mt-1 text-sm text-red-600"
-                    role="alert"
-                  >
-                    {usdOriginalError}
-                  </p>
-                ) : null}
-              </div>
-            </fieldset>
-
-            <fieldset className="space-y-2">
-              <legend className="text-muted-foreground text-xs font-medium">
-                UAH (optional)
+                UAH (standard storefront)
               </legend>
 
               <div>
@@ -951,12 +898,68 @@ export function ProductForm({
                 ) : null}
               </div>
             </fieldset>
+
+            <fieldset className="space-y-2">
+              <legend className="text-muted-foreground text-xs font-medium">
+                USD (compatibility optional)
+              </legend>
+
+              <div>
+                <label className={LABEL_CLASS} htmlFor="price-usd">
+                  Price (USD)
+                </label>
+                <input
+                  id="price-usd"
+                  name="price-usd"
+                  className={INPUT_CLASS}
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="59.00"
+                  value={usdRow?.price ?? ''}
+                  onChange={e => setPriceField('USD', 'price', e.target.value)}
+                />
+              </div>
+
+              <div>
+                <label className={LABEL_CLASS} htmlFor="original-usd">
+                  Original price (USD)
+                </label>
+                <input
+                  id="original-usd"
+                  name="original-usd"
+                  className={cn(
+                    INPUT_CLASS,
+                    usdOriginalError && 'border-red-500'
+                  )}
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="79.00"
+                  value={usdRow?.originalPrice ?? ''}
+                  onChange={e =>
+                    setPriceField('USD', 'originalPrice', e.target.value)
+                  }
+                  aria-invalid={usdOriginalError ? true : undefined}
+                  aria-describedby={
+                    usdOriginalError ? usdOriginalErrorId : undefined
+                  }
+                />
+                {usdOriginalError ? (
+                  <p
+                    id={usdOriginalErrorId}
+                    className="mt-1 text-sm text-red-600"
+                    role="alert"
+                  >
+                    {usdOriginalError}
+                  </p>
+                ) : null}
+              </div>
+            </fieldset>
           </div>
 
           <p className="text-muted-foreground mt-3 text-xs">
-            Checkout currency is server-selected by locale. Prices must exist in{' '}
-            <span className="font-mono">product_prices</span> for that currency,
-            or checkout fails.
+            Standard storefront checkout uses UAH. Prices must exist in{' '}
+            <span className="font-mono">product_prices</span> for the standard
+            storefront currency. USD is optional compatibility only.
           </p>
         </fieldset>
 

--- a/frontend/app/[locale]/admin/shop/products/_components/ProductForm.tsx
+++ b/frontend/app/[locale]/admin/shop/products/_components/ProductForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useTranslations } from 'next-intl';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useRouter } from '@/i18n/routing';
@@ -65,8 +66,6 @@ type SaleRuleDetails = {
   rule?: 'required' | 'greater_than_price';
 };
 
-const SALE_REQUIRED_MSG = 'Original price is required for SALE.';
-const SALE_GREATER_MSG = 'Original price must be greater than price for SALE.';
 const CARD_CLASS =
   'rounded-xl border border-border bg-background/80 p-5 shadow-sm';
 const LABEL_CLASS = 'block text-sm font-medium text-foreground';
@@ -81,6 +80,16 @@ const SECONDARY_BUTTON_CLASS =
 const PRIMARY_BUTTON_CLASS =
   'inline-flex h-10 w-full items-center justify-center rounded-md bg-foreground px-4 text-sm font-semibold text-background transition-colors hover:bg-foreground/90 disabled:opacity-60';
 
+class InvalidMoneyValueError extends Error {
+  rawValue: string;
+
+  constructor(rawValue: string) {
+    super('INVALID_MONEY_VALUE');
+    this.name = 'InvalidMoneyValueError';
+    this.rawValue = rawValue;
+  }
+}
+
 function formatMinorToMajor(value: number): string {
   if (!Number.isFinite(value)) return '';
   const abs = Math.abs(Math.trunc(value));
@@ -93,13 +102,13 @@ function formatMinorToMajor(value: number): string {
 function parseMajorToMinor(value: string): number {
   const s = value.trim().replace(',', '.');
   if (!/^\d+(\.\d{1,2})?$/.test(s)) {
-    throw new Error(`Invalid money value: "${value}"`);
+    throw new InvalidMoneyValueError(value);
   }
   const [whole, frac = ''] = s.split('.');
   const frac2 = (frac + '00').slice(0, 2);
   const minor = Number(whole) * 100 + Number(frac2);
   if (!Number.isSafeInteger(minor) || minor < 0) {
-    throw new Error(`Invalid money value: "${value}"`);
+    throw new InvalidMoneyValueError(value);
   }
   return minor;
 }
@@ -185,8 +194,9 @@ function isSerializableUiPhoto(photo: UiPhoto): photo is SerializableUiPhoto {
   return false;
 }
 
-export const LEGACY_PHOTO_MIGRATION_REQUIRED_MESSAGE =
-  'Legacy product photos must be migrated before adding or reordering gallery photos.';
+type ProductFormErrorMessages = {
+  legacyPhotoMigrationRequired: string;
+};
 
 class PhotoPlanSubmissionError extends Error {
   constructor(message: string) {
@@ -195,22 +205,28 @@ class PhotoPlanSubmissionError extends Error {
   }
 }
 
-export function getPhotoPlanSubmissionError(photos: UiPhoto[]): string | null {
+export function getPhotoPlanSubmissionError(
+  photos: UiPhoto[],
+  messages: ProductFormErrorMessages
+): string | null {
   const hasLegacyPhotos = photos.some(photo => photo.source === 'legacy');
   const hasNonLegacyPhotos = photos.some(photo => photo.source !== 'legacy');
 
   if (hasLegacyPhotos && hasNonLegacyPhotos) {
-    return LEGACY_PHOTO_MIGRATION_REQUIRED_MESSAGE;
+    return messages.legacyPhotoMigrationRequired;
   }
 
   return null;
 }
 
-export function buildPhotoPlanSubmission(photos: UiPhoto[]): {
+export function buildPhotoPlanSubmission(
+  photos: UiPhoto[],
+  messages: ProductFormErrorMessages
+): {
   photoPlan?: AdminProductPhotoPlan;
   newPhotos: Array<UiPhoto & { source: 'new'; uploadId: string; file: File }>;
 } {
-  const submissionError = getPhotoPlanSubmissionError(photos);
+  const submissionError = getPhotoPlanSubmissionError(photos, messages);
   if (submissionError) {
     throw new PhotoPlanSubmissionError(submissionError);
   }
@@ -311,6 +327,7 @@ export function ProductForm({
   csrfToken,
 }: ProductFormProps) {
   const router = useRouter();
+  const t = useTranslations('shop.admin.products.form');
 
   const idBase = useMemo(() => {
     const pid =
@@ -563,7 +580,7 @@ export function ProductForm({
     setOriginalPriceErrors({});
 
     if (photos.length === 0) {
-      setImageError('At least one product photo is required.');
+      setImageError(t('errors.photoRequired'));
       return;
     }
 
@@ -581,14 +598,24 @@ export function ProductForm({
       );
 
       if (effectivePrices.length === 0) {
-        setError('At least one price is required.');
+        setError(t('errors.atLeastOnePrice'));
+        return;
+      }
+
+      const storefrontUahPrice = normalizedPrices.find(
+        price => price.currency === 'UAH'
+      );
+      if (!storefrontUahPrice?.price.length) {
+        setError(t('errors.uahRequired'));
         return;
       }
 
       for (const p of effectivePrices) {
         if (!p.price.length && p.originalPrice.length) {
           setError(
-            `${p.currency}: price is required when original price is set.`
+            t('errors.priceRequiredWhenOriginalSet', {
+              currency: p.currency,
+            })
           );
           return;
         }
@@ -609,7 +636,11 @@ export function ProductForm({
             : null,
         }));
       } catch (e) {
-        setError(e instanceof Error ? e.message : 'Invalid price value.');
+        if (e instanceof InvalidMoneyValueError) {
+          setError(t('errors.invalidMoneyValue', { value: e.rawValue }));
+          return;
+        }
+        setError(t('errors.invalidPriceValue'));
         return;
       }
 
@@ -633,7 +664,11 @@ export function ProductForm({
 
       const photoSubmission = (() => {
         try {
-          return buildPhotoPlanSubmission(photos);
+          return buildPhotoPlanSubmission(photos, {
+            legacyPhotoMigrationRequired: t(
+              'errors.legacyPhotoMigrationRequired'
+            ),
+          });
         } catch (photoPlanError) {
           if (photoPlanError instanceof PhotoPlanSubmissionError) {
             setImageError(photoPlanError.message);
@@ -662,7 +697,7 @@ export function ProductForm({
       }
 
       if (!csrfToken) {
-        setError('Security token missing. Refresh the page and retry.');
+        setError(t('errors.securityMissing'));
         setIsSubmitting(false);
         return;
       }
@@ -684,7 +719,7 @@ export function ProductForm({
 
       if (!response.ok) {
         if (data.code === 'SLUG_CONFLICT' || data.field === 'slug') {
-          setSlugError('This slug is already used. Try changing the title.');
+          setSlugError(t('errors.slugConflict'));
         }
 
         const photoErrorFields = new Set([
@@ -701,7 +736,7 @@ export function ProductForm({
           data.code === 'IMAGE_UPLOAD_FAILED' ||
           data.code === 'IMAGE_REQUIRED'
         ) {
-          setImageError(data.error ?? 'Failed to update product photos');
+          setImageError(data.error ?? t('errors.photoUpdateFailed'));
           return;
         }
 
@@ -710,8 +745,8 @@ export function ProductForm({
           const currency = details?.currency;
           const msg =
             details?.rule === 'greater_than_price'
-              ? SALE_GREATER_MSG
-              : SALE_REQUIRED_MSG;
+              ? t('errors.saleOriginalGreater')
+              : t('errors.saleOriginalRequired');
 
           if (currency === 'USD' || currency === 'UAH') {
             setOriginalPriceErrors(prev => ({ ...prev, [currency]: msg }));
@@ -725,13 +760,15 @@ export function ProductForm({
           response.status === 403 &&
           (data.code === 'CSRF_MISSING' || data.code === 'CSRF_INVALID')
         ) {
-          setError('Security token expired. Refresh the page and retry.');
+          setError(t('errors.securityExpired'));
           return;
         }
 
         setError(
           data.error ??
-            `Failed to ${mode === 'create' ? 'create' : 'update'} product`
+            (mode === 'create'
+              ? t('errors.createFailed')
+              : t('errors.updateFailed'))
         );
         return;
       }
@@ -746,9 +783,9 @@ export function ProductForm({
       });
 
       setError(
-        `Unexpected error while ${
-          mode === 'create' ? 'creating' : 'updating'
-        } product.`
+        mode === 'create'
+          ? t('errors.unexpectedCreate')
+          : t('errors.unexpectedUpdate')
       );
     } finally {
       setIsSubmitting(false);
@@ -762,7 +799,7 @@ export function ProductForm({
   return (
     <section aria-labelledby={headingId}>
       <h2 id={headingId} className="sr-only">
-        {mode === 'create' ? 'Create new product' : 'Edit product'}
+        {mode === 'create' ? t('headings.create') : t('headings.edit')}
       </h2>
       {error ? (
         <div
@@ -783,11 +820,11 @@ export function ProductForm({
       >
         <section
           className={cn(CARD_CLASS, 'grid gap-4 sm:grid-cols-2')}
-          aria-label="Basic info"
+          aria-label={t('sections.basicInfo')}
         >
           <div>
             <label className={LABEL_CLASS} htmlFor="title">
-              Title
+              {t('fields.title')}
             </label>
             <input
               id="title"
@@ -803,10 +840,10 @@ export function ProductForm({
           <div>
             <div className="flex items-center justify-between">
               <label className={LABEL_CLASS} htmlFor="slug">
-                Slug
+                {t('fields.slug')}
               </label>
               <span id={slugHelpId} className="text-muted-foreground text-xs">
-                Auto-generated from title
+                {t('fields.slugHelp')}
               </span>
             </div>
             <input
@@ -834,23 +871,22 @@ export function ProductForm({
 
         <fieldset className={CARD_CLASS}>
           <legend className="text-foreground px-1 text-sm font-semibold">
-            Prices
+            {t('pricing.legend')}
           </legend>
 
           <p className="text-muted-foreground mt-2 text-xs">
-            UAH is the standard storefront price. USD is optional and kept only
-            as a compatibility price.
+            {t('pricing.helper')}
           </p>
 
           <div className="mt-3 grid gap-4 sm:grid-cols-2">
             <fieldset className="space-y-2">
               <legend className="text-muted-foreground text-xs font-medium">
-                UAH (standard storefront)
+                {t('pricing.uahLegend')}
               </legend>
 
               <div>
                 <label className={LABEL_CLASS} htmlFor="price-uah">
-                  Price (UAH)
+                  {t('fields.price', { currency: 'UAH' })}
                 </label>
                 <input
                   id="price-uah"
@@ -866,7 +902,7 @@ export function ProductForm({
 
               <div>
                 <label className={LABEL_CLASS} htmlFor="original-uah">
-                  Original price (UAH)
+                  {t('fields.originalPrice', { currency: 'UAH' })}
                 </label>
                 <input
                   id="original-uah"
@@ -901,12 +937,12 @@ export function ProductForm({
 
             <fieldset className="space-y-2">
               <legend className="text-muted-foreground text-xs font-medium">
-                USD (compatibility optional)
+                {t('pricing.usdLegend')}
               </legend>
 
               <div>
                 <label className={LABEL_CLASS} htmlFor="price-usd">
-                  Price (USD)
+                  {t('fields.price', { currency: 'USD' })}
                 </label>
                 <input
                   id="price-usd"
@@ -922,7 +958,7 @@ export function ProductForm({
 
               <div>
                 <label className={LABEL_CLASS} htmlFor="original-usd">
-                  Original price (USD)
+                  {t('fields.originalPrice', { currency: 'USD' })}
                 </label>
                 <input
                   id="original-usd"
@@ -957,19 +993,19 @@ export function ProductForm({
           </div>
 
           <p className="text-muted-foreground mt-3 text-xs">
-            Standard storefront checkout uses UAH. Prices must exist in{' '}
-            <span className="font-mono">product_prices</span> for the standard
-            storefront currency. USD is optional compatibility only.
+            {t('pricing.policyPrefix')}{' '}
+            <span className="font-mono">product_prices</span>{' '}
+            {t('pricing.policySuffix')}
           </p>
         </fieldset>
 
         <section
           className={cn(CARD_CLASS, 'grid gap-4 sm:grid-cols-2')}
-          aria-label="Inventory and SKU"
+          aria-label={t('sections.inventorySku')}
         >
           <div>
             <label className={LABEL_CLASS} htmlFor="stock">
-              Stock
+              {t('fields.stock')}
             </label>
             <input
               id="stock"
@@ -985,7 +1021,7 @@ export function ProductForm({
 
           <div>
             <label className={LABEL_CLASS} htmlFor="sku">
-              SKU
+              {t('fields.sku')}
             </label>
             <input
               id="sku"
@@ -1000,11 +1036,11 @@ export function ProductForm({
 
         <section
           className={cn(CARD_CLASS, 'grid gap-4 sm:grid-cols-2')}
-          aria-label="Catalog attributes"
+          aria-label={t('sections.catalogAttributes')}
         >
           <div>
             <label className={LABEL_CLASS} htmlFor="category">
-              Category
+              {t('fields.category')}
             </label>
             <select
               id="category"
@@ -1013,7 +1049,7 @@ export function ProductForm({
               value={category}
               onChange={event => setCategory(event.target.value)}
             >
-              <option value="">Select category</option>
+              <option value="">{t('fields.selectCategory')}</option>
               {CATEGORIES.filter(
                 categoryOption => categoryOption.slug !== 'all'
               ).map(categoryOption => (
@@ -1026,7 +1062,7 @@ export function ProductForm({
 
           <div>
             <label className={LABEL_CLASS} htmlFor="type">
-              Type
+              {t('fields.type')}
             </label>
             <select
               id="type"
@@ -1035,7 +1071,7 @@ export function ProductForm({
               value={type}
               onChange={event => setType(event.target.value)}
             >
-              <option value="">Select type</option>
+              <option value="">{t('fields.selectType')}</option>
               {PRODUCT_TYPES.map(productType => (
                 <option key={productType.slug} value={productType.slug}>
                   {productType.label}
@@ -1047,10 +1083,10 @@ export function ProductForm({
 
         <section
           className={cn(CARD_CLASS, 'grid gap-4 sm:grid-cols-2')}
-          aria-label="Variants"
+          aria-label={t('sections.variants')}
         >
           <fieldset>
-            <legend className={LABEL_CLASS}>Colors</legend>
+            <legend className={LABEL_CLASS}>{t('fields.colors')}</legend>
             <div className="border-border bg-muted/20 mt-2 flex flex-col gap-2 rounded-lg border px-3 py-3">
               {COLORS.map(color => (
                 <label
@@ -1080,7 +1116,7 @@ export function ProductForm({
           </fieldset>
 
           <fieldset>
-            <legend className={LABEL_CLASS}>Sizes</legend>
+            <legend className={LABEL_CLASS}>{t('fields.sizes')}</legend>
             <div className="border-border bg-muted/20 mt-2 flex flex-col gap-2 rounded-lg border px-3 py-3">
               {SIZES.map(size => (
                 <label
@@ -1110,11 +1146,11 @@ export function ProductForm({
 
         <section
           className={cn(CARD_CLASS, 'grid gap-4 sm:grid-cols-2')}
-          aria-label="Flags and badge"
+          aria-label={t('sections.flagsBadge')}
         >
           <div>
             <label className={LABEL_CLASS} htmlFor="badge">
-              Badge
+              {t('fields.badge')}
             </label>
             <select
               id="badge"
@@ -1130,9 +1166,9 @@ export function ProductForm({
                 }
               }}
             >
-              <option value="NONE">None</option>
-              <option value="SALE">SALE</option>
-              <option value="NEW">NEW</option>
+              <option value="NONE">{t('badge.none')}</option>
+              <option value="SALE">{t('badge.sale')}</option>
+              <option value="NEW">{t('badge.new')}</option>
             </select>
           </div>
 
@@ -1150,7 +1186,7 @@ export function ProductForm({
                 className="text-foreground text-sm font-medium"
                 htmlFor="isActive"
               >
-                Is Active
+                {t('fields.isActive')}
               </label>
             </div>
 
@@ -1167,15 +1203,15 @@ export function ProductForm({
                 className="text-foreground text-sm font-medium"
                 htmlFor="isFeatured"
               >
-                Is Featured
+                {t('fields.isFeatured')}
               </label>
             </div>
           </div>
         </section>
 
-        <section className={CARD_CLASS} aria-label="Description">
+        <section className={CARD_CLASS} aria-label={t('sections.description')}>
           <label className={LABEL_CLASS} htmlFor="description">
-            Description
+            {t('fields.description')}
           </label>
           <textarea
             id="description"
@@ -1187,9 +1223,9 @@ export function ProductForm({
           />
         </section>
 
-        <section className={CARD_CLASS} aria-label="Photo management">
+        <section className={CARD_CLASS} aria-label={t('sections.photoManagement')}>
           <label className={LABEL_CLASS} htmlFor="images">
-            Photos
+            {t('fields.photos')}
           </label>
           <input
             id="images"
@@ -1203,8 +1239,7 @@ export function ProductForm({
             aria-describedby={imageError ? imageErrorId : undefined}
           />
           <p className="text-muted-foreground mt-2 text-sm">
-            Add one or more photos, reorder them, and mark exactly one as
-            primary.
+            {t('photos.helper')}
           </p>
           {photos.length > 0 ? (
             <div className="mt-4 space-y-3">
@@ -1215,7 +1250,7 @@ export function ProductForm({
                 >
                   <Image
                     src={photo.previewUrl}
-                    alt={`Product photo ${index + 1}`}
+                    alt={t('photos.photoAlt', { index: index + 1 })}
                     width={96}
                     height={96}
                     unoptimized
@@ -1223,18 +1258,20 @@ export function ProductForm({
                   />
                   <div className="min-w-0 flex-1 space-y-2">
                     <div className="flex flex-wrap items-center gap-2 text-sm">
-                      <span className="font-medium">Photo {index + 1}</span>
+                      <span className="font-medium">
+                        {t('photos.photoLabel', { index: index + 1 })}
+                      </span>
                       {photo.isPrimary ? (
                         <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-500">
-                          Primary
+                          {t('photos.primary')}
                         </span>
                       ) : null}
                       <span className="text-muted-foreground text-xs">
                         {photo.source === 'existing'
-                          ? 'Saved'
+                          ? t('photos.status.saved')
                           : photo.source === 'legacy'
-                            ? 'Legacy image'
-                            : 'New upload'}
+                            ? t('photos.status.legacy')
+                            : t('photos.status.new')}
                       </span>
                     </div>
 
@@ -1245,7 +1282,7 @@ export function ProductForm({
                         onClick={() => setPrimaryPhoto(photo.key)}
                         disabled={photo.isPrimary}
                       >
-                        Set primary
+                        {t('photos.actions.setPrimary')}
                       </button>
                       <button
                         type="button"
@@ -1253,7 +1290,7 @@ export function ProductForm({
                         onClick={() => movePhoto(photo.key, -1)}
                         disabled={index === 0}
                       >
-                        Move up
+                        {t('photos.actions.moveUp')}
                       </button>
                       <button
                         type="button"
@@ -1261,14 +1298,14 @@ export function ProductForm({
                         onClick={() => movePhoto(photo.key, 1)}
                         disabled={index === photos.length - 1}
                       >
-                        Move down
+                        {t('photos.actions.moveDown')}
                       </button>
                       <button
                         type="button"
                         className="inline-flex h-8 items-center justify-center rounded-md border border-red-500/30 px-3 text-xs font-medium text-red-500 transition-colors hover:bg-red-500/10"
                         onClick={() => removePhoto(photo.key)}
                       >
-                        Remove
+                        {t('photos.actions.remove')}
                       </button>
                     </div>
                   </div>
@@ -1296,11 +1333,11 @@ export function ProductForm({
         >
           {isSubmitting
             ? mode === 'create'
-              ? 'Creating...'
-              : 'Updating...'
+              ? t('actions.creating')
+              : t('actions.updating')
             : mode === 'create'
-              ? 'Create product'
-              : 'Save changes'}
+              ? t('actions.create')
+              : t('actions.save')}
         </button>
       </form>
     </section>

--- a/frontend/app/[locale]/shop/cart/CartPageClient.tsx
+++ b/frontend/app/[locale]/shop/cart/CartPageClient.tsx
@@ -275,36 +275,27 @@ function isWarehouseMethod(
 function resolveShippingMethodCardCopy(args: {
   methodCode: CheckoutDeliveryMethodCode;
   fallbackTitle: string;
-  safeT: (key: string, fallback: string) => string;
+  translate: (key: string) => string;
 }): { title: string; description: string } {
-  const { methodCode, fallbackTitle, safeT } = args;
+  const { methodCode, fallbackTitle, translate } = args;
 
   switch (methodCode) {
     case 'NP_WAREHOUSE':
       return {
-        title: safeT('delivery.methodCards.warehouse.title', fallbackTitle),
-        description: safeT(
-          'delivery.methodCards.warehouse.description',
-          'Pick up at a Nova Poshta branch'
-        ),
+        title: translate('delivery.methodCards.warehouse.title'),
+        description: translate('delivery.methodCards.warehouse.description'),
       };
 
     case 'NP_LOCKER':
       return {
-        title: safeT('delivery.methodCards.locker.title', fallbackTitle),
-        description: safeT(
-          'delivery.methodCards.locker.description',
-          'Pick up from a Nova Poshta parcel locker'
-        ),
+        title: translate('delivery.methodCards.locker.title'),
+        description: translate('delivery.methodCards.locker.description'),
       };
 
     case 'NP_COURIER':
       return {
-        title: safeT('delivery.methodCards.courier.title', fallbackTitle),
-        description: safeT(
-          'delivery.methodCards.courier.description',
-          'Nova Poshta door-to-door delivery'
-        ),
+        title: translate('delivery.methodCards.courier.title'),
+        description: translate('delivery.methodCards.courier.description'),
       };
 
     default:
@@ -1722,7 +1713,7 @@ export default function CartPage({
                         const cardCopy = resolveShippingMethodCardCopy({
                           methodCode: method.methodCode,
                           fallbackTitle: method.title,
-                          safeT,
+                          translate: key => t(key as any),
                         });
 
                         return (

--- a/frontend/app/[locale]/shop/cart/CartPageClient.tsx
+++ b/frontend/app/[locale]/shop/cart/CartPageClient.tsx
@@ -14,9 +14,9 @@ import {
   type CheckoutDeliveryMethodCode,
   type ShippingAvailabilityReasonCode,
 } from '@/lib/services/shop/shipping/checkout-payload';
+import { resolveStandardStorefrontShippingCountry } from '@/lib/shop/commercial-policy';
 import { formatMoney } from '@/lib/shop/currency';
 import { generateIdempotencyKey } from '@/lib/shop/idempotency';
-import { localeToCountry } from '@/lib/shop/locale';
 import {
   SHOP_CART_CARD,
   SHOP_CART_FIELD,
@@ -41,6 +41,11 @@ import {
   shopCtaGradient,
 } from '@/lib/shop/ui-classes';
 import { cn } from '@/lib/utils';
+
+import {
+  resolveDefaultMethodForProvider,
+  resolveInitialProvider,
+} from './provider-policy';
 
 type Props = {
   stripeEnabled: boolean;
@@ -80,31 +85,6 @@ type ShippingWarehouse = {
   address: string | null;
   isPostMachine: boolean;
 };
-
-function resolveInitialProvider(args: {
-  stripeEnabled: boolean;
-  monobankEnabled: boolean;
-  currency: string | null | undefined;
-}): CheckoutProvider {
-  const isUah = args.currency === 'UAH';
-  const canUseStripe = args.stripeEnabled;
-  const canUseMonobank = args.monobankEnabled && isUah;
-
-  if (canUseMonobank) return 'monobank';
-  if (canUseStripe) return 'stripe';
-  return 'stripe';
-}
-
-function resolveDefaultMethodForProvider(args: {
-  provider: CheckoutProvider;
-  currency: string | null | undefined;
-}): CheckoutPaymentMethod | null {
-  if (args.provider === 'stripe') return 'stripe_card';
-  if (args.provider === 'monobank') {
-    return args.currency === 'UAH' ? 'monobank_invoice' : null;
-  }
-  return null;
-}
 
 function normalizeLookupValue(value: string): string {
   return value.trim().toLocaleLowerCase();
@@ -502,12 +482,11 @@ export default function CartPage({
   const params = useParams<{ locale?: string }>();
   const locale = params.locale ?? 'en';
   const shopBase = '/shop';
-  const isUahCheckout = cart.summary.currency === 'UAH';
   const canUseStripe = stripeEnabled;
-  const canUseMonobank = monobankEnabled && isUahCheckout;
+  const canUseMonobank = monobankEnabled;
   const canUseMonobankGooglePay = canUseMonobank && monobankGooglePayEnabled;
   const hasSelectableProvider = canUseStripe || canUseMonobank;
-  const country = localeToCountry(locale);
+  const country = resolveStandardStorefrontShippingCountry();
 
   const shippingUnavailableHardBlock =
     shippingReasonCode === 'SHOP_SHIPPING_DISABLED' ||
@@ -1121,11 +1100,7 @@ export default function CartPage({
     }
 
     if (selectedProvider === 'monobank' && !canUseMonobank) {
-      setCheckoutError(
-        monobankEnabled
-          ? t('checkout.paymentMethod.monobankUahOnlyHint')
-          : t('checkout.paymentMethod.monobankUnavailable')
-      );
+      setCheckoutError(t('checkout.paymentMethod.monobankUnavailable'));
       return;
     }
 
@@ -2238,9 +2213,7 @@ export default function CartPage({
 
                 {!canUseMonobank ? (
                   <p className="text-muted-foreground mt-3 text-xs">
-                    {monobankEnabled
-                      ? t('checkout.paymentMethod.monobankUahOnlyHint')
-                      : t('checkout.paymentMethod.monobankUnavailable')}
+                    {t('checkout.paymentMethod.monobankUnavailable')}
                   </p>
                 ) : null}
 

--- a/frontend/app/[locale]/shop/cart/capabilities.ts
+++ b/frontend/app/[locale]/shop/cart/capabilities.ts
@@ -1,37 +1,14 @@
-import { isMonobankEnabled } from '@/lib/env/monobank';
-import { readServerEnv } from '@/lib/env/server-env';
-import { isPaymentsEnabled as isStripePaymentsEnabled } from '@/lib/env/stripe';
-
-function isFlagEnabled(value: string | undefined): boolean {
-  return (value ?? '').trim() === 'true';
-}
+import { resolveStandardStorefrontProviderCapabilities } from '@/lib/shop/commercial-policy.server';
 
 export function resolveStripeCheckoutEnabled(): boolean {
-  try {
-    return isStripePaymentsEnabled({
-      requirePublishableKey: true,
-    });
-  } catch {
-    return false;
-  }
+  return resolveStandardStorefrontProviderCapabilities().stripeCheckoutEnabled;
 }
 
 export function resolveMonobankCheckoutEnabled(): boolean {
-  const paymentsEnabled = isFlagEnabled(readServerEnv('PAYMENTS_ENABLED'));
-  if (!paymentsEnabled) return false;
-
-  try {
-    return isMonobankEnabled();
-  } catch {
-    return false;
-  }
+  return resolveStandardStorefrontProviderCapabilities().monobankCheckoutEnabled;
 }
 
 export function resolveMonobankGooglePayEnabled(): boolean {
-  if (!resolveMonobankCheckoutEnabled()) return false;
-
-  const raw = (readServerEnv('SHOP_MONOBANK_GPAY_ENABLED') ?? '')
-    .trim()
-    .toLowerCase();
-  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+  return resolveStandardStorefrontProviderCapabilities()
+    .monobankGooglePayEnabled;
 }

--- a/frontend/app/[locale]/shop/cart/provider-policy.ts
+++ b/frontend/app/[locale]/shop/cart/provider-policy.ts
@@ -1,0 +1,33 @@
+type CheckoutProvider = 'stripe' | 'monobank';
+type CheckoutPaymentMethod =
+  | 'stripe_card'
+  | 'monobank_invoice'
+  | 'monobank_google_pay';
+
+export function resolveInitialProvider(args: {
+  stripeEnabled: boolean;
+  monobankEnabled: boolean;
+  currency: string | null | undefined;
+}): CheckoutProvider {
+  void args.currency;
+
+  const canUseStripe = args.stripeEnabled;
+  const canUseMonobank = args.monobankEnabled;
+
+  if (canUseMonobank) return 'monobank';
+  if (canUseStripe) return 'stripe';
+  return 'stripe';
+}
+
+export function resolveDefaultMethodForProvider(args: {
+  provider: CheckoutProvider;
+  currency: string | null | undefined;
+}): CheckoutPaymentMethod | null {
+  void args.currency;
+
+  if (args.provider === 'stripe') return 'stripe_card';
+  if (args.provider === 'monobank') {
+    return 'monobank_invoice';
+  }
+  return null;
+}

--- a/frontend/app/[locale]/shop/checkout/error/page.tsx
+++ b/frontend/app/[locale]/shop/checkout/error/page.tsx
@@ -20,8 +20,16 @@ import {
 import { cn } from '@/lib/utils';
 import { orderIdParamSchema } from '@/lib/validation/shop';
 
-export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations('shop.checkout.errorPage');
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({
+    locale,
+    namespace: 'shop.checkout.errorPage',
+  });
 
   return {
     title: t('metaTitle'),

--- a/frontend/app/[locale]/shop/checkout/error/page.tsx
+++ b/frontend/app/[locale]/shop/checkout/error/page.tsx
@@ -231,11 +231,9 @@ export default async function CheckoutErrorPage({
   const isFailed = order.paymentStatus === 'failed';
 
   const totalMinor =
-    typeof (order as any).totalAmountMinor === 'number'
-      ? (order as any).totalAmountMinor
-      : null;
+    typeof order.totalAmountMinor === 'number' ? order.totalAmountMinor : null;
 
-  const currency = resolveCheckoutDisplayCurrency((order as any).currency);
+  const currency = resolveCheckoutDisplayCurrency(order.currency);
 
   return (
     <main

--- a/frontend/app/[locale]/shop/checkout/error/page.tsx
+++ b/frontend/app/[locale]/shop/checkout/error/page.tsx
@@ -20,11 +20,14 @@ import {
 import { cn } from '@/lib/utils';
 import { orderIdParamSchema } from '@/lib/validation/shop';
 
-export const metadata: Metadata = {
-  title: 'Checkout Error | DevLovers',
-  description:
-    'We couldn’t complete the checkout. Try again or contact support.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('shop.checkout.errorPage');
+
+  return {
+    title: t('metaTitle'),
+    description: t('metaDescription'),
+  };
+}
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -103,7 +106,7 @@ export default async function CheckoutErrorPage({
 
           <nav
             className="mt-6 flex flex-wrap justify-center gap-3"
-            aria-label="Checkout navigation"
+            aria-label={t('errorPage.checkoutNavigation')}
           >
             <Link href="/shop/cart" className={SHOP_OUTLINE_BTN}>
               {t('actions.backToCart')}
@@ -162,7 +165,7 @@ export default async function CheckoutErrorPage({
 
             <nav
               className="mt-6 flex flex-wrap justify-center gap-3"
-              aria-label="Checkout navigation"
+              aria-label={t('errorPage.checkoutNavigation')}
             >
               <Link href="/shop/cart" className={SHOP_OUTLINE_BTN}>
                 {t('actions.backToCart')}
@@ -248,7 +251,7 @@ export default async function CheckoutErrorPage({
 
         <section
           className="border-border bg-muted/30 text-foreground mt-6 rounded-md border p-4 text-sm"
-          aria-label="Order details"
+          aria-label={t('errorPage.orderDetails')}
         >
           <dl className="space-y-2">
             <div className="flex items-center justify-between gap-4">
@@ -278,7 +281,10 @@ export default async function CheckoutErrorPage({
           </dl>
         </section>
 
-        <nav className="mt-6 flex flex-wrap gap-3" aria-label="Next steps">
+        <nav
+          className="mt-6 flex flex-wrap gap-3"
+          aria-label={t('errorPage.nextSteps')}
+        >
           <Link href="/shop/cart" className={SHOP_OUTLINE_BTN}>
             {t('actions.backToCart')}
           </Link>

--- a/frontend/app/[locale]/shop/checkout/error/page.tsx
+++ b/frontend/app/[locale]/shop/checkout/error/page.tsx
@@ -4,7 +4,8 @@ import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/routing';
 import { OrderNotFoundError } from '@/lib/services/errors';
 import { getOrderSummary } from '@/lib/services/orders';
-import { formatMoney, resolveCurrencyFromLocale } from '@/lib/shop/currency';
+import { resolveCheckoutDisplayCurrency } from '@/lib/shop/checkout-display-currency';
+import { formatMoney } from '@/lib/shop/currency';
 import {
   SHOP_CTA_BASE,
   SHOP_CTA_INSET,
@@ -223,7 +224,7 @@ export default async function CheckoutErrorPage({
       ? (order as any).totalAmountMinor
       : null;
 
-  const currency = (order as any).currency ?? resolveCurrencyFromLocale(locale);
+  const currency = resolveCheckoutDisplayCurrency((order as any).currency);
 
   return (
     <main

--- a/frontend/app/[locale]/shop/checkout/error/page.tsx
+++ b/frontend/app/[locale]/shop/checkout/error/page.tsx
@@ -42,6 +42,10 @@ export const revalidate = 0;
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
+function isPromise<T>(value: unknown): value is Promise<T> {
+  return !!value && typeof (value as any).then === 'function';
+}
+
 function getStringParam(params: SearchParams | undefined, key: string): string {
   if (!params) return '';
   const raw = params[key];
@@ -87,10 +91,9 @@ export default async function CheckoutErrorPage({
   const { locale } = await params;
   const t = await getTranslations('shop.checkout');
 
-  const resolvedSearchParams: SearchParams | undefined =
-    searchParams && typeof (searchParams as any).then === 'function'
-      ? await (searchParams as Promise<SearchParams>)
-      : (searchParams as SearchParams | undefined);
+  const resolvedSearchParams = isPromise<SearchParams>(searchParams)
+    ? await searchParams
+    : searchParams;
 
   const orderId = parseOrderId(resolvedSearchParams);
   const statusToken = parseStatusToken(resolvedSearchParams);

--- a/frontend/app/[locale]/shop/checkout/payment/StripePaymentClient.tsx
+++ b/frontend/app/[locale]/shop/checkout/payment/StripePaymentClient.tsx
@@ -11,6 +11,7 @@ import {
   type Stripe,
   type StripeElementsOptions,
 } from '@stripe/stripe-js';
+import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
 
 import { Link, useRouter } from '@/i18n/routing';
@@ -150,6 +151,7 @@ function StripePaymentForm({ orderId, locale, statusToken }: PaymentFormProps) {
   const stripe = useStripe();
   const elements = useElements();
   const router = useRouter();
+  const t = useTranslations('shop.checkout.paymentClient');
 
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -159,9 +161,7 @@ function StripePaymentForm({ orderId, locale, statusToken }: PaymentFormProps) {
     setErrorMessage(null);
 
     if (!stripe || !elements) {
-      setErrorMessage(
-        'Payment is not ready yet. Please try again in a moment.'
-      );
+      setErrorMessage(t('messages.notReady'));
       return;
     }
 
@@ -189,7 +189,7 @@ function StripePaymentForm({ orderId, locale, statusToken }: PaymentFormProps) {
       });
 
       if (error) {
-        setErrorMessage(error.message ?? 'Unable to confirm payment.');
+        setErrorMessage(error.message ?? t('messages.confirmFailed'));
         router.push(inAppFailure);
         return;
       }
@@ -208,7 +208,7 @@ function StripePaymentForm({ orderId, locale, statusToken }: PaymentFormProps) {
         : '';
 
       logError('stripe_payment_confirm_failed', error, { orderId });
-      setErrorMessage('We couldn’t confirm your payment. Please try again.');
+      setErrorMessage(t('messages.unexpectedConfirmFailed'));
       router.push(
         buildInAppPath(`/checkout/error?orderId=${id}${tokenSuffix}`)
       );
@@ -221,7 +221,7 @@ function StripePaymentForm({ orderId, locale, statusToken }: PaymentFormProps) {
     <form
       onSubmit={handleSubmit}
       className="space-y-4"
-      aria-label="Stripe payment form"
+      aria-label={t('aria.form')}
     >
       <PaymentElement />
 
@@ -232,7 +232,7 @@ function StripePaymentForm({ orderId, locale, statusToken }: PaymentFormProps) {
         aria-disabled={!stripe || submitting}
       >
         <HeroCtaInner>
-          {submitting ? 'Processing...' : 'Submit payment'}
+          {submitting ? t('actions.processing') : t('actions.submit')}
         </HeroCtaInner>
       </button>
 
@@ -255,6 +255,7 @@ export default function StripePaymentClient({
   currency,
   locale,
 }: StripePaymentClientProps) {
+  const t = useTranslations('shop.checkout.paymentClient');
   const uiCurrency = useMemo(
     () => resolveCheckoutDisplayCurrency(currency),
     [currency]
@@ -277,13 +278,13 @@ export default function StripePaymentClient({
     return (
       <section
         className="text-muted-foreground space-y-3 text-sm"
-        aria-label="Payments disabled"
+        aria-label={t('aria.paymentsDisabled')}
       >
-        <p>Payments are disabled in this environment.</p>
+        <p>{t('messages.paymentsDisabled')}</p>
 
         <nav
           className="flex flex-col gap-3 sm:flex-row"
-          aria-label="Next steps"
+          aria-label={t('aria.nextSteps')}
         >
           <Link
             href={buildInAppPath(
@@ -291,14 +292,14 @@ export default function StripePaymentClient({
             )}
             className={cn(SHOP_HERO_CTA, 'w-full sm:w-auto')}
           >
-            <HeroCtaInner>Continue</HeroCtaInner>
+            <HeroCtaInner>{t('actions.continue')}</HeroCtaInner>
           </Link>
 
           <Link
             href={buildInAppPath('/cart')}
             className={cn(SHOP_OUTLINE, 'w-full sm:w-auto')}
           >
-            Back to cart
+            {t('actions.backToCart')}
           </Link>
         </nav>
       </section>
@@ -309,15 +310,15 @@ export default function StripePaymentClient({
     return (
       <section
         className="text-muted-foreground space-y-3 text-sm"
-        aria-label="Payment initialization failed"
+        aria-label={t('aria.paymentInitializationFailed')}
       >
-        <p>Payment cannot be initialized. Please try again later.</p>
+        <p>{t('messages.initializationFailed')}</p>
 
         <Link
           href={buildInAppPath('/cart')}
           className={cn(SHOP_OUTLINE, 'w-full sm:w-auto')}
         >
-          Return to cart
+          {t('actions.returnToCart')}
         </Link>
       </section>
     );
@@ -326,18 +327,20 @@ export default function StripePaymentClient({
   if (!stripePromise || !options) {
     return (
       <p className="text-muted-foreground text-sm" aria-live="polite">
-        Preparing secure payment…
+        {t('messages.preparing')}
       </p>
     );
   }
 
   return (
-    <section aria-label="Secure payment">
+    <section aria-label={t('aria.securePayment')}>
       <Elements stripe={stripePromise as Promise<Stripe>} options={options}>
         <div className="space-y-4">
           <div className="border-border bg-muted/40 text-foreground rounded-md border p-3 text-sm">
             <div className="flex items-center justify-between">
-              <span className="text-muted-foreground">Pay</span>
+              <span className="text-muted-foreground">
+                {t('summary.payLabel')}
+              </span>
               <span className="text-base font-semibold">
                 {formatMoney(amountMinor, uiCurrency, locale)}
               </span>

--- a/frontend/app/[locale]/shop/checkout/payment/StripePaymentClient.tsx
+++ b/frontend/app/[locale]/shop/checkout/payment/StripePaymentClient.tsx
@@ -15,12 +15,8 @@ import { useMemo, useState } from 'react';
 
 import { Link, useRouter } from '@/i18n/routing';
 import { logError } from '@/lib/logging';
-import {
-  type CurrencyCode,
-  currencyValues,
-  formatMoney,
-  resolveCurrencyFromLocale,
-} from '@/lib/shop/currency';
+import { resolveCheckoutDisplayCurrency } from '@/lib/shop/checkout-display-currency';
+import { formatMoney } from '@/lib/shop/currency';
 import {
   SHOP_CTA_BASE,
   SHOP_CTA_INSET,
@@ -50,16 +46,6 @@ type StripePaymentClientProps = {
   currency: string;
   locale: string;
 };
-
-function toCurrencyCode(
-  value: string | null | undefined,
-  locale: string
-): CurrencyCode {
-  const normalized = (value ?? '').trim().toUpperCase();
-  return currencyValues.includes(normalized as CurrencyCode)
-    ? (normalized as CurrencyCode)
-    : resolveCurrencyFromLocale(locale);
-}
 
 const IN_APP_SHOP_BASE = '/shop';
 
@@ -270,8 +256,8 @@ export default function StripePaymentClient({
   locale,
 }: StripePaymentClientProps) {
   const uiCurrency = useMemo(
-    () => toCurrencyCode(currency, locale),
-    [currency, locale]
+    () => resolveCheckoutDisplayCurrency(currency),
+    [currency]
   );
 
   const stripePromise = useMemo(() => {

--- a/frontend/app/api/shop/cart/rehydrate/route.ts
+++ b/frontend/app/api/shop/cart/rehydrate/route.ts
@@ -6,7 +6,7 @@ import { MoneyValueError } from '@/db/queries/shop/orders';
 import { logError, logInfo, logWarn } from '@/lib/logging';
 import { InvalidPayloadError, PriceConfigError } from '@/lib/services/errors';
 import { rehydrateCartItems } from '@/lib/services/products';
-import { resolveLocaleAndCurrency } from '@/lib/shop/request-locale';
+import { resolveStandardStorefrontCurrency } from '@/lib/shop/commercial-policy';
 import { cartRehydratePayloadSchema } from '@/lib/validation/shop';
 
 function normalizeCartPayload(body: unknown) {
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
     route: request.nextUrl.pathname,
     method: request.method,
   };
-  const { currency } = resolveLocaleAndCurrency(request);
+  const currency = resolveStandardStorefrontCurrency();
 
   const meta = {
     ...baseMeta,

--- a/frontend/app/api/shop/checkout/route.ts
+++ b/frontend/app/api/shop/checkout/route.ts
@@ -4,9 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { MoneyValueError } from '@/db/queries/shop/orders';
 import { getCurrentUser } from '@/lib/auth';
-import { isMonobankEnabled } from '@/lib/env/monobank';
 import { readPositiveIntEnv } from '@/lib/env/readPositiveIntEnv';
-import { isPaymentsEnabled as isStripePaymentsEnabled } from '@/lib/env/stripe';
 import { logError, logInfo, logWarn } from '@/lib/logging';
 import { MONO_MISMATCH, monoLogWarn } from '@/lib/logging/monobank';
 import { guardBrowserSameOrigin } from '@/lib/security/origin';
@@ -33,7 +31,11 @@ import {
   ensureStripePaymentIntentForOrder,
   PaymentAttemptsExhaustedError,
 } from '@/lib/services/orders/payment-attempts';
-import { resolveCurrencyFromLocale } from '@/lib/shop/currency';
+import {
+  resolveStandardStorefrontCheckoutProviderCandidates,
+  resolveStandardStorefrontCurrency,
+} from '@/lib/shop/commercial-policy';
+import { resolveStandardStorefrontProviderCapabilities } from '@/lib/shop/commercial-policy.server';
 import {
   isMethodAllowed,
   type PaymentMethod,
@@ -41,7 +43,6 @@ import {
   paymentProviderValues,
   type PaymentStatus,
   paymentStatusValues,
-  resolveCheckoutProviderCandidates,
   resolveDefaultMethodForProvider,
 } from '@/lib/shop/payments';
 import { resolveRequestLocale } from '@/lib/shop/request-locale';
@@ -175,13 +176,6 @@ function parseRequestedMethod(raw: unknown): PaymentMethod | 'invalid' | null {
 function isMonoAlias(raw: unknown): boolean {
   if (typeof raw !== 'string') return false;
   return raw.trim().toLowerCase() === 'mono';
-}
-
-function isMonobankGooglePayEnabled(): boolean {
-  const raw = (process.env.SHOP_MONOBANK_GPAY_ENABLED ?? '')
-    .trim()
-    .toLowerCase();
-  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
 }
 
 function stripMonobankClientMoneyFields(payload: unknown): unknown {
@@ -880,27 +874,18 @@ export async function POST(request: NextRequest) {
     payloadForValidation = rest;
   }
 
-  const localeCurrency = resolveCurrencyFromLocale(locale);
-  const paymentsEnabled =
-    (process.env.PAYMENTS_ENABLED ?? '').trim() === 'true';
+  const storefrontCurrency = resolveStandardStorefrontCurrency();
+  const providerCapabilities =
+    resolveStandardStorefrontProviderCapabilities();
+  const stripeCheckoutAvailable =
+    providerCapabilities.stripeCheckoutEnabled;
+  const monobankCheckoutAvailable =
+    providerCapabilities.monobankCheckoutEnabled;
 
-  const stripeCheckoutAvailable = isStripePaymentsEnabled({
-    requirePublishableKey: true,
-  });
-  let monobankCheckoutAvailable = false;
-  try {
-    monobankCheckoutAvailable = paymentsEnabled && isMonobankEnabled();
-  } catch (error) {
-    logError('monobank_env_invalid', error, {
-      ...baseMeta,
-      code: 'MONOBANK_ENV_INVALID',
-    });
-  }
-
-  const checkoutProviderCandidates = resolveCheckoutProviderCandidates({
+  const checkoutProviderCandidates =
+    resolveStandardStorefrontCheckoutProviderCandidates({
     requestedProvider,
     requestedMethod,
-    currency: localeCurrency,
   });
   const selectedProvider =
     checkoutProviderCandidates.find(candidate =>
@@ -911,8 +896,7 @@ export async function POST(request: NextRequest) {
 
   const fallbackProvider =
     selectedProvider ?? checkoutProviderCandidates[0] ?? null;
-  const selectedCurrency =
-    fallbackProvider === 'monobank' ? 'UAH' : localeCurrency;
+  const selectedCurrency = storefrontCurrency;
   const selectedMethod =
     requestedMethod ??
     (fallbackProvider
@@ -934,7 +918,7 @@ export async function POST(request: NextRequest) {
       code: 'PAYMENTS_DISABLED',
       requestedProvider,
       requestedMethod,
-      localeCurrency,
+      storefrontCurrency,
       candidates: checkoutProviderCandidates,
       stripeCheckoutAvailable,
       monobankCheckoutAvailable,
@@ -953,7 +937,7 @@ export async function POST(request: NextRequest) {
       code: 'PAYMENTS_DISABLED',
       requestedProvider,
       requestedMethod,
-      localeCurrency,
+      storefrontCurrency,
       candidates: checkoutProviderCandidates,
       stripeCheckoutAvailable,
       monobankCheckoutAvailable,
@@ -973,7 +957,7 @@ export async function POST(request: NextRequest) {
       code: 'PAYMENTS_DISABLED',
       requestedProvider,
       requestedMethod,
-      localeCurrency,
+      storefrontCurrency,
       candidates: checkoutProviderCandidates,
       stripeCheckoutAvailable,
       monobankCheckoutAvailable,
@@ -988,7 +972,7 @@ export async function POST(request: NextRequest) {
 
   if (
     selectedMethod === 'monobank_google_pay' &&
-    !isMonobankGooglePayEnabled()
+    !providerCapabilities.monobankGooglePayEnabled
   ) {
     return errorResponse('INVALID_REQUEST', 'Invalid request.', 422);
   }
@@ -998,7 +982,10 @@ export async function POST(request: NextRequest) {
       provider: resolvedProvider,
       method: selectedMethod,
       currency: selectedCurrency,
-      flags: { monobankGooglePayEnabled: isMonobankGooglePayEnabled() },
+      flags: {
+        monobankGooglePayEnabled:
+          providerCapabilities.monobankGooglePayEnabled,
+      },
     })
   ) {
     if (resolvedProvider === 'monobank') {

--- a/frontend/app/api/shop/shipping/methods/route.ts
+++ b/frontend/app/api/shop/shipping/methods/route.ts
@@ -23,7 +23,10 @@ import {
   sanitizeShippingErrorForLog,
   sanitizeShippingLogMeta,
 } from '@/lib/services/shop/shipping/log-sanitizer';
-import { resolveCurrencyFromLocale } from '@/lib/shop/currency';
+import {
+  resolveStandardStorefrontCurrency,
+  resolveStandardStorefrontShippingCountry,
+} from '@/lib/shop/commercial-policy';
 import { resolveRequestLocale } from '@/lib/shop/request-locale';
 import { shippingMethodsQuerySchema } from '@/lib/validation/shop-shipping';
 
@@ -172,13 +175,15 @@ export async function GET(request: NextRequest) {
 
   try {
     const locale = parsed.data.locale ?? resolveRequestLocale(request);
-    const currency = parsed.data.currency ?? resolveCurrencyFromLocale(locale);
+    const currency =
+      parsed.data.currency ?? resolveStandardStorefrontCurrency();
     const flags = getShopShippingFlags();
     const availability = resolveShippingAvailability({
       shippingEnabled: flags.shippingEnabled,
       npEnabled: flags.npEnabled,
       locale,
-      country: parsed.data.country ?? null,
+      country:
+        parsed.data.country ?? resolveStandardStorefrontShippingCountry(),
       currency,
     });
 

--- a/frontend/app/api/shop/shipping/np/cities/route.ts
+++ b/frontend/app/api/shop/shipping/np/cities/route.ts
@@ -20,7 +20,10 @@ import {
 } from '@/lib/services/shop/shipping/log-sanitizer';
 import { findCitiesWithCacheOnMiss } from '@/lib/services/shop/shipping/nova-poshta-catalog';
 import { NovaPoshtaApiError } from '@/lib/services/shop/shipping/nova-poshta-client';
-import { resolveCurrencyFromLocale } from '@/lib/shop/currency';
+import {
+  resolveStandardStorefrontCurrency,
+  resolveStandardStorefrontShippingCountry,
+} from '@/lib/shop/commercial-policy';
 import { resolveRequestLocale } from '@/lib/shop/request-locale';
 import { shippingCitiesQuerySchema } from '@/lib/validation/shop-shipping';
 
@@ -92,13 +95,13 @@ export async function GET(request: NextRequest) {
   }
 
   const locale = parsed.data.locale ?? resolveRequestLocale(request);
-  const currency = parsed.data.currency ?? resolveCurrencyFromLocale(locale);
+  const currency = parsed.data.currency ?? resolveStandardStorefrontCurrency();
   const flags = getShopShippingFlags();
   const availability = resolveShippingAvailability({
     shippingEnabled: flags.shippingEnabled,
     npEnabled: flags.npEnabled,
     locale,
-    country: parsed.data.country ?? null,
+    country: parsed.data.country ?? resolveStandardStorefrontShippingCountry(),
     currency,
   });
 

--- a/frontend/app/api/shop/shipping/np/warehouses/route.ts
+++ b/frontend/app/api/shop/shipping/np/warehouses/route.ts
@@ -20,7 +20,10 @@ import {
 } from '@/lib/services/shop/shipping/log-sanitizer';
 import { findWarehousesWithCacheOnMiss } from '@/lib/services/shop/shipping/nova-poshta-catalog';
 import { NovaPoshtaApiError } from '@/lib/services/shop/shipping/nova-poshta-client';
-import { resolveCurrencyFromLocale } from '@/lib/shop/currency';
+import {
+  resolveStandardStorefrontCurrency,
+  resolveStandardStorefrontShippingCountry,
+} from '@/lib/shop/commercial-policy';
 import { resolveRequestLocale } from '@/lib/shop/request-locale';
 import { shippingWarehousesQuerySchema } from '@/lib/validation/shop-shipping';
 
@@ -95,13 +98,13 @@ export async function GET(request: NextRequest) {
   }
 
   const locale = parsed.data.locale ?? resolveRequestLocale(request);
-  const currency = parsed.data.currency ?? resolveCurrencyFromLocale(locale);
+  const currency = parsed.data.currency ?? resolveStandardStorefrontCurrency();
   const flags = getShopShippingFlags();
   const availability = resolveShippingAvailability({
     shippingEnabled: flags.shippingEnabled,
     npEnabled: flags.npEnabled,
     locale,
-    country: parsed.data.country ?? null,
+    country: parsed.data.country ?? resolveStandardStorefrontShippingCountry(),
     currency,
   });
 

--- a/frontend/docs/shop/commercial-policy-batch-cp-01-acceptance.md
+++ b/frontend/docs/shop/commercial-policy-batch-cp-01-acceptance.md
@@ -1,0 +1,49 @@
+# Batch CP-01 Acceptance Gate
+
+This note is the merge/release gate for the coupled PR-C + PR-D batch.
+
+## Scope
+
+- Standard storefront public read paths
+- Standard storefront checkout/write enforcement
+- Shipping read paths for the UA storefront
+- Snapshot and Monobank regression-sensitive paths
+
+## Automated Acceptance Targets
+
+- `uk` / `en` / `pl` public storefront reads resolve `UAH`
+- Products with only a `UAH` price row stay visible on non-`uk` locales
+- Stripe visibility is capability/env-based, not locale-based
+- Monobank visibility is capability/env-based, not locale-based
+- Shipping methods and NP lookup read paths work on non-`uk` locales for the UA
+  storefront
+- Standard storefront checkout persists `UAH` on `uk` / `en` / `pl`
+- Provider rail selection is locale-agnostic for the standard storefront
+- Client currency fields do not control persisted order currency
+- Monobank payment init and idempotency remain intact
+- Order item snapshots remain structurally stable after CP-01
+
+## Manual Smoke Checklist
+
+Manual browser smoke was not executed in the coding environment. A human release
+check should confirm:
+
+1. On `uk`, `en`, and `pl`, open catalog and PDP pages and confirm displayed
+   prices are `UAH`.
+2. On `uk`, `en`, and `pl`, open the cart with payments enabled and confirm both
+   Stripe and Monobank options are visible.
+3. On `en` or `pl`, open checkout with a shippable cart and confirm Nova Poshta
+   methods load without needing locale `uk`.
+4. On `en` or `pl`, complete a Stripe checkout attempt and confirm the created
+   order shows `UAH`.
+5. On `en` or `pl`, complete a Monobank checkout attempt and confirm the payment
+   page opens and the order shows `UAH`.
+6. Open checkout recovery/error/status pages and confirm displayed money remains
+   `UAH` for standard storefront orders.
+
+## Release Rule
+
+- `intl` remains untouched in Batch CP-01.
+- Schema remains untouched in Batch CP-01.
+- Dormant `USD` remains a compatibility path only.
+- PR-C and PR-D must ship together as one release batch.

--- a/frontend/docs/shop/commercial-policy-batch-cp-01.md
+++ b/frontend/docs/shop/commercial-policy-batch-cp-01.md
@@ -1,0 +1,99 @@
+# Shop Commercial Policy Memo
+
+## Status
+
+Approved for Batch CP-01 preparation work.
+
+## Purpose
+
+This memo records the target commercial policy for the standard Shop storefront
+without changing runtime behavior in PR-A.
+
+It exists to keep policy decisions explicit while checkout/storefront
+implementation work is staged across later PRs.
+
+---
+
+## Batch CP-01 Policy
+
+### 1. Locale
+
+Locale is a language/content selector only.
+
+Locale must not be the long-term source of truth for:
+
+- storefront currency,
+- payment rail availability,
+- commercial market selection.
+
+### 2. Standard Storefront Currency
+
+The standard storefront currency target is **UAH** on all locales.
+
+This is the intended commercial policy for the standard storefront, not a
+statement that runtime behavior has already switched in this PR.
+
+### 3. Standard Storefront Payment Providers
+
+The standard storefront payment rails are:
+
+- Stripe
+- Monobank
+
+Provider availability must ultimately be controlled by env/runtime capability
+only. Locale must not be the gate.
+
+### 4. Intl Flow
+
+The existing `intl` flow remains untouched in Batch CP-01.
+
+This batch does not redesign, widen, or clean up the `intl` quote/payment
+contract.
+
+### 5. Dormant USD Compatibility
+
+USD compatibility remains temporarily in place as a dormant compatibility path.
+
+This includes legacy/storage compatibility that may still be required while the
+policy refactor is staged safely.
+
+Batch CP-01 does not require immediate USD removal.
+
+### 6. Schema Cleanup
+
+No schema cleanup is part of this batch.
+
+That means:
+
+- no migrations,
+- no enum cleanup,
+- no legacy compatibility removal,
+- no destructive price/currency schema changes.
+
+---
+
+## PR-A Scope Guardrail
+
+PR-A is preparation only.
+
+Allowed in PR-A:
+
+- documenting the policy,
+- repairing stale targeted tests so they reach their intended assertions.
+
+Not allowed in PR-A:
+
+- switching storefront currency behavior,
+- switching checkout/provider enforcement behavior,
+- changing admin pricing policy,
+- cleaning up schema or dormant compatibility paths.
+
+---
+
+## Interpretation Rule
+
+If code, tests, or follow-up implementation planning conflict with this memo,
+this memo defines the intended Batch CP-01 target policy.
+
+Runtime behavior changes must be delivered only in later PRs with explicit scope
+approval.

--- a/frontend/docs/shop/commercial-policy-batch-cp-01.md
+++ b/frontend/docs/shop/commercial-policy-batch-cp-01.md
@@ -4,6 +4,9 @@
 
 Approved for Batch CP-01 preparation work.
 
+This memo was written for PR-A to record the intended policy before the runtime
+switches landed in later CP-01 PRs.
+
 ## Purpose
 
 This memo records the target commercial policy for the standard Shop storefront

--- a/frontend/lib/services/orders/checkout.ts
+++ b/frontend/lib/services/orders/checkout.ts
@@ -28,8 +28,11 @@ import {
   resolveCheckoutShippingQuote,
 } from '@/lib/services/shop/shipping/checkout-quote';
 import { createCheckoutPricingFingerprint } from '@/lib/shop/checkout-pricing';
-import { resolveCurrencyFromLocale } from '@/lib/shop/currency';
-import { localeToCountry } from '@/lib/shop/locale';
+import {
+  resolveStandardStorefrontCheckoutProviderCandidates,
+  resolveStandardStorefrontCurrency,
+  resolveStandardStorefrontShippingCountry,
+} from '@/lib/shop/commercial-policy';
 import {
   calculateLineTotal,
   fromCents,
@@ -40,7 +43,6 @@ import {
   type PaymentMethod,
   type PaymentProvider,
   type PaymentStatus,
-  resolveCheckoutProviderCandidates,
   resolveDefaultMethodForProvider,
 } from '@/lib/shop/payments';
 import {
@@ -356,7 +358,7 @@ async function prepareCheckoutShipping(args: {
     shippingEnabled: flags.shippingEnabled,
     npEnabled: flags.npEnabled,
     locale: args.locale ?? null,
-    country: args.country ?? localeToCountry(args.locale),
+    country: args.country ?? resolveStandardStorefrontShippingCountry(),
     currency: args.currency,
   });
 
@@ -603,7 +605,7 @@ function resolveCheckoutLegalConsent(args: {
   const source = 'checkout_explicit';
   const normalizedLocale = normVariant(args.locale).toLowerCase() || null;
   const normalizedCountry = normalizeCountryCode(
-    args.country ?? localeToCountry(args.locale)
+    args.country ?? resolveStandardStorefrontShippingCountry()
   );
 
   return {
@@ -862,19 +864,18 @@ export async function createOrderWithItems({
     });
   }
 
-  const localeCurrency: Currency = resolveCurrencyFromLocale(locale);
-  const checkoutProviderCandidates = resolveCheckoutProviderCandidates({
+  const storefrontCurrency: Currency = resolveStandardStorefrontCurrency();
+  const checkoutProviderCandidates =
+    resolveStandardStorefrontCheckoutProviderCandidates({
     requestedProvider:
       requestedProvider === 'stripe' || requestedProvider === 'monobank'
         ? requestedProvider
         : null,
     requestedMethod,
-    currency: localeCurrency,
   });
   const paymentProvider: PaymentProvider =
     checkoutProviderCandidates[0] ?? 'stripe';
-  const currency: Currency =
-    paymentProvider === 'monobank' ? 'UAH' : localeCurrency;
+  const currency: Currency = storefrontCurrency;
 
   const initialPaymentStatus: PaymentStatus = 'pending';
   const resolvedPaymentMethod = resolveCheckoutPaymentMethod({

--- a/frontend/lib/services/products/mutations/create.ts
+++ b/frontend/lib/services/products/mutations/create.ts
@@ -12,6 +12,7 @@ import { InvalidPayloadError, SlugConflictError } from '../../errors';
 import { mapRowToProduct } from '../mapping';
 import { resolvePhotoPlan } from '../photo-plan';
 import {
+  assertMergedPricesPolicy,
   enforceSaleBadgeRequiresOriginal,
   normalizePricesFromInput,
   resolveLegacyCompatPriceMirror,
@@ -31,6 +32,10 @@ export async function createProduct(input: ProductInput): Promise<DbProduct> {
   }
 
   validatePriceRows(prices);
+  assertMergedPricesPolicy(prices, {
+    requiredCurrency: 'UAH',
+    requireUsd: false,
+  });
 
   const badge = (input as any).badge ?? 'NONE';
   enforceSaleBadgeRequiresOriginal(badge, prices);

--- a/frontend/lib/services/products/mutations/create.ts
+++ b/frontend/lib/services/products/mutations/create.ts
@@ -14,7 +14,7 @@ import { resolvePhotoPlan } from '../photo-plan';
 import {
   enforceSaleBadgeRequiresOriginal,
   normalizePricesFromInput,
-  requireUsd,
+  resolveLegacyCompatPriceMirror,
   validatePriceRows,
 } from '../prices';
 import { normalizeSlug } from '../slug';
@@ -35,7 +35,7 @@ export async function createProduct(input: ProductInput): Promise<DbProduct> {
   const badge = (input as any).badge ?? 'NONE';
   enforceSaleBadgeRequiresOriginal(badge, prices);
 
-  const usd = requireUsd(prices);
+  const legacyMirror = resolveLegacyCompatPriceMirror(prices);
 
   const legacyImage =
     (input as any).image instanceof File && (input as any).image.size > 0
@@ -142,11 +142,14 @@ export async function createProduct(input: ProductInput): Promise<DbProduct> {
           description: (input as any).description ?? null,
           imageUrl: primaryUpload.secureUrl,
           imagePublicId: primaryUpload.publicId,
-          price: toDbMoney(usd.priceMinor),
+          // Legacy products.* price fields remain schema-constrained to USD.
+          // When no dormant USD row is supplied, mirror the canonical admin row
+          // for compatibility only while product_prices stays authoritative.
+          price: toDbMoney(legacyMirror.priceMinor),
           originalPrice:
-            usd.originalPriceMinor == null
+            legacyMirror.originalPriceMinor == null
               ? null
-              : toDbMoney(usd.originalPriceMinor),
+              : toDbMoney(legacyMirror.originalPriceMinor),
           currency: 'USD',
 
           category: (input as any).category ?? null,

--- a/frontend/lib/services/products/mutations/update.ts
+++ b/frontend/lib/services/products/mutations/update.ts
@@ -116,7 +116,10 @@ export async function updateProduct(
     const mergedRows = Array.from(merged.values());
 
     if (prices.length) {
-      assertMergedPricesPolicy(mergedRows, { productId: id, requireUsd: true });
+      assertMergedPricesPolicy(mergedRows, {
+        productId: id,
+        requireUsd: false,
+      });
     }
 
     if (finalBadge === 'SALE') {

--- a/frontend/lib/services/products/mutations/update.ts
+++ b/frontend/lib/services/products/mutations/update.ts
@@ -118,6 +118,7 @@ export async function updateProduct(
     if (prices.length) {
       assertMergedPricesPolicy(mergedRows, {
         productId: id,
+        requiredCurrency: 'UAH',
         requireUsd: false,
       });
     }

--- a/frontend/lib/services/products/mutations/update.ts
+++ b/frontend/lib/services/products/mutations/update.ts
@@ -80,52 +80,48 @@ export async function updateProduct(
 
   const finalBadge = (input as any).badge ?? existing.badge;
 
-  if (prices.length || finalBadge === 'SALE') {
-    const existingPriceRows = await db
-      .select({
-        currency: productPrices.currency,
-        priceMinor: productPrices.priceMinor,
-        originalPriceMinor: productPrices.originalPriceMinor,
-      })
-      .from(productPrices)
-      .where(eq(productPrices.productId, id));
+  const existingPriceRows = await db
+    .select({
+      currency: productPrices.currency,
+      priceMinor: productPrices.priceMinor,
+      originalPriceMinor: productPrices.originalPriceMinor,
+    })
+    .from(productPrices)
+    .where(eq(productPrices.productId, id));
 
-    const merged = new Map<CurrencyCode, NormalizedPriceRow>();
+  const merged = new Map<CurrencyCode, NormalizedPriceRow>();
 
-    for (const r of existingPriceRows) {
-      merged.set(r.currency as CurrencyCode, {
-        currency: r.currency as CurrencyCode,
-        priceMinor: assertMoneyMinorInt(
-          r.priceMinor,
-          `${String(r.currency)} priceMinor`
-        ),
-        originalPriceMinor:
-          r.originalPriceMinor == null
-            ? null
-            : assertMoneyMinorInt(
-                r.originalPriceMinor,
-                `${String(r.currency)} originalPriceMinor`
-              ),
-      });
-    }
+  for (const r of existingPriceRows) {
+    merged.set(r.currency as CurrencyCode, {
+      currency: r.currency as CurrencyCode,
+      priceMinor: assertMoneyMinorInt(
+        r.priceMinor,
+        `${String(r.currency)} priceMinor`
+      ),
+      originalPriceMinor:
+        r.originalPriceMinor == null
+          ? null
+          : assertMoneyMinorInt(
+              r.originalPriceMinor,
+              `${String(r.currency)} originalPriceMinor`
+            ),
+    });
+  }
 
-    for (const p of prices) {
-      merged.set(p.currency, p);
-    }
+  for (const p of prices) {
+    merged.set(p.currency, p);
+  }
 
-    const mergedRows = Array.from(merged.values());
+  const mergedRows = Array.from(merged.values());
 
-    if (prices.length) {
-      assertMergedPricesPolicy(mergedRows, {
-        productId: id,
-        requiredCurrency: 'UAH',
-        requireUsd: false,
-      });
-    }
+  assertMergedPricesPolicy(mergedRows, {
+    productId: id,
+    requiredCurrency: 'UAH',
+    requireUsd: false,
+  });
 
-    if (finalBadge === 'SALE') {
-      enforceSaleBadgeRequiresOriginal('SALE', mergedRows);
-    }
+  if (finalBadge === 'SALE') {
+    enforceSaleBadgeRequiresOriginal('SALE', mergedRows);
   }
 
   let resolvedPhotoPlan: ReturnType<typeof resolvePhotoPlan> | undefined;

--- a/frontend/lib/services/products/mutations/update.ts
+++ b/frontend/lib/services/products/mutations/update.ts
@@ -80,50 +80,6 @@ export async function updateProduct(
 
   const finalBadge = (input as any).badge ?? existing.badge;
 
-  const existingPriceRows = await db
-    .select({
-      currency: productPrices.currency,
-      priceMinor: productPrices.priceMinor,
-      originalPriceMinor: productPrices.originalPriceMinor,
-    })
-    .from(productPrices)
-    .where(eq(productPrices.productId, id));
-
-  const merged = new Map<CurrencyCode, NormalizedPriceRow>();
-
-  for (const r of existingPriceRows) {
-    merged.set(r.currency as CurrencyCode, {
-      currency: r.currency as CurrencyCode,
-      priceMinor: assertMoneyMinorInt(
-        r.priceMinor,
-        `${String(r.currency)} priceMinor`
-      ),
-      originalPriceMinor:
-        r.originalPriceMinor == null
-          ? null
-          : assertMoneyMinorInt(
-              r.originalPriceMinor,
-              `${String(r.currency)} originalPriceMinor`
-            ),
-    });
-  }
-
-  for (const p of prices) {
-    merged.set(p.currency, p);
-  }
-
-  const mergedRows = Array.from(merged.values());
-
-  assertMergedPricesPolicy(mergedRows, {
-    productId: id,
-    requiredCurrency: 'UAH',
-    requireUsd: false,
-  });
-
-  if (finalBadge === 'SALE') {
-    enforceSaleBadgeRequiresOriginal('SALE', mergedRows);
-  }
-
   let resolvedPhotoPlan: ReturnType<typeof resolvePhotoPlan> | undefined;
   const uploadedById = new Map<
     string,
@@ -224,6 +180,51 @@ export async function updateProduct(
 
   try {
     const row = await db.transaction(async tx => {
+      const existingPriceRows = await tx
+        .select({
+          currency: productPrices.currency,
+          priceMinor: productPrices.priceMinor,
+          originalPriceMinor: productPrices.originalPriceMinor,
+        })
+        .from(productPrices)
+        .where(eq(productPrices.productId, id))
+        .for('update');
+
+      const merged = new Map<CurrencyCode, NormalizedPriceRow>();
+
+      for (const r of existingPriceRows) {
+        merged.set(r.currency as CurrencyCode, {
+          currency: r.currency as CurrencyCode,
+          priceMinor: assertMoneyMinorInt(
+            r.priceMinor,
+            `${String(r.currency)} priceMinor`
+          ),
+          originalPriceMinor:
+            r.originalPriceMinor == null
+              ? null
+              : assertMoneyMinorInt(
+                  r.originalPriceMinor,
+                  `${String(r.currency)} originalPriceMinor`
+                ),
+        });
+      }
+
+      for (const p of prices) {
+        merged.set(p.currency, p);
+      }
+
+      const mergedRows = Array.from(merged.values());
+
+      assertMergedPricesPolicy(mergedRows, {
+        productId: id,
+        requiredCurrency: 'UAH',
+        requireUsd: false,
+      });
+
+      if (finalBadge === 'SALE') {
+        enforceSaleBadgeRequiresOriginal('SALE', mergedRows);
+      }
+
       if (prices.length) {
         const upsertRows = prices.map(p => {
           const priceMinor = p.priceMinor;

--- a/frontend/lib/services/products/prices.ts
+++ b/frontend/lib/services/products/prices.ts
@@ -57,12 +57,29 @@ function assertOptionalMoneyString(
 }
 export function assertMergedPricesPolicy(
   merged: NormalizedPriceRow[],
-  options?: { productId?: string; requireUsd?: boolean }
+  options?: {
+    productId?: string;
+    requireUsd?: boolean;
+    requiredCurrency?: CurrencyCode;
+  }
 ) {
   if (!merged.length) {
     throw new PriceConfigError('At least one price is required.', {
       productId: options?.productId,
     });
+  }
+
+  const requiredCurrency = options?.requiredCurrency;
+  if (requiredCurrency) {
+    const hasRequiredCurrency = merged.some(
+      p => p.currency === requiredCurrency && p.priceMinor >= 1
+    );
+    if (!hasRequiredCurrency) {
+      throw new PriceConfigError(`${requiredCurrency} price is required.`, {
+        productId: options?.productId,
+        currency: requiredCurrency,
+      });
+    }
   }
 
   const requireUsd = options?.requireUsd ?? true;

--- a/frontend/lib/services/products/prices.ts
+++ b/frontend/lib/services/products/prices.ts
@@ -76,6 +76,24 @@ export function assertMergedPricesPolicy(
     }
   }
 }
+
+export function resolveLegacyCompatPriceMirror(
+  prices: NormalizedPriceRow[]
+): NormalizedPriceRow {
+  const usd = prices.find(p => p.currency === 'USD' && p.priceMinor >= 1);
+  if (usd) return usd;
+
+  const storefrontFallback = prices.find(
+    p => p.currency === 'UAH' && p.priceMinor >= 1
+  );
+  if (storefrontFallback) return storefrontFallback;
+
+  const firstUsable = prices.find(p => p.priceMinor >= 1);
+  if (firstUsable) return firstUsable;
+
+  throw new InvalidPayloadError('At least one price is required.');
+}
+
 function toMoneyMinor(value: string, field: string): number {
   const n = assertMoneyString(value, field);
   return toCents(n);
@@ -170,14 +188,6 @@ export function normalizePricesFromInput(input: unknown): NormalizedPriceRow[] {
   }
 
   return [];
-}
-
-export function requireUsd(prices: NormalizedPriceRow[]): NormalizedPriceRow {
-  const usd = prices.find(p => p.currency === 'USD');
-  if (!usd?.priceMinor) {
-    throw new InvalidPayloadError('USD price is required.');
-  }
-  return usd;
 }
 
 export function validatePriceRows(prices: NormalizedPriceRow[]) {

--- a/frontend/lib/shop/checkout-display-currency.ts
+++ b/frontend/lib/shop/checkout-display-currency.ts
@@ -1,0 +1,13 @@
+import { type CurrencyCode, currencyValues } from '@/lib/shop/currency';
+
+import { resolveStandardStorefrontCurrency } from './commercial-policy';
+
+export function resolveCheckoutDisplayCurrency(
+  value: string | null | undefined
+): CurrencyCode {
+  const normalized = (value ?? '').trim().toUpperCase();
+
+  return currencyValues.includes(normalized as CurrencyCode)
+    ? (normalized as CurrencyCode)
+    : resolveStandardStorefrontCurrency();
+}

--- a/frontend/lib/shop/commercial-policy.server.ts
+++ b/frontend/lib/shop/commercial-policy.server.ts
@@ -1,0 +1,61 @@
+import 'server-only';
+
+import { isMonobankEnabled } from '@/lib/env/monobank';
+import { readServerEnv } from '@/lib/env/server-env';
+import { isPaymentsEnabled as isStripePaymentsEnabled } from '@/lib/env/stripe';
+
+export type StandardStorefrontProviderCapabilities = {
+  stripeCheckoutEnabled: boolean;
+  monobankCheckoutEnabled: boolean;
+  monobankGooglePayEnabled: boolean;
+  enabledProviders: ReadonlyArray<'monobank' | 'stripe'>;
+};
+
+function isFlagEnabled(value: string | undefined): boolean {
+  return (value ?? '').trim() === 'true';
+}
+
+export function resolveStandardStorefrontProviderCapabilities(): StandardStorefrontProviderCapabilities {
+  let stripeCheckoutEnabled = false;
+  try {
+    stripeCheckoutEnabled = isStripePaymentsEnabled({
+      requirePublishableKey: true,
+    });
+  } catch {
+    stripeCheckoutEnabled = false;
+  }
+
+  const paymentsEnabled = isFlagEnabled(readServerEnv('PAYMENTS_ENABLED'));
+
+  let monobankCheckoutEnabled = false;
+  if (paymentsEnabled) {
+    try {
+      monobankCheckoutEnabled = isMonobankEnabled();
+    } catch {
+      monobankCheckoutEnabled = false;
+    }
+  }
+
+  const rawMonobankGooglePay = (
+    readServerEnv('SHOP_MONOBANK_GPAY_ENABLED') ?? ''
+  )
+    .trim()
+    .toLowerCase();
+  const monobankGooglePayEnabled =
+    monobankCheckoutEnabled &&
+    (rawMonobankGooglePay === 'true' ||
+      rawMonobankGooglePay === '1' ||
+      rawMonobankGooglePay === 'yes' ||
+      rawMonobankGooglePay === 'on');
+
+  const enabledProviders: Array<'monobank' | 'stripe'> = [];
+  if (monobankCheckoutEnabled) enabledProviders.push('monobank');
+  if (stripeCheckoutEnabled) enabledProviders.push('stripe');
+
+  return {
+    stripeCheckoutEnabled,
+    monobankCheckoutEnabled,
+    monobankGooglePayEnabled,
+    enabledProviders,
+  };
+}

--- a/frontend/lib/shop/commercial-policy.server.ts
+++ b/frontend/lib/shop/commercial-policy.server.ts
@@ -12,7 +12,13 @@ export type StandardStorefrontProviderCapabilities = {
 };
 
 function isFlagEnabled(value: string | undefined): boolean {
-  return (value ?? '').trim() === 'true';
+  const normalized = (value ?? '').trim().toLowerCase();
+  return (
+    normalized === 'true' ||
+    normalized === '1' ||
+    normalized === 'yes' ||
+    normalized === 'on'
+  );
 }
 
 export function resolveStandardStorefrontProviderCapabilities(): StandardStorefrontProviderCapabilities {
@@ -36,17 +42,9 @@ export function resolveStandardStorefrontProviderCapabilities(): StandardStorefr
     }
   }
 
-  const rawMonobankGooglePay = (
-    readServerEnv('SHOP_MONOBANK_GPAY_ENABLED') ?? ''
-  )
-    .trim()
-    .toLowerCase();
   const monobankGooglePayEnabled =
     monobankCheckoutEnabled &&
-    (rawMonobankGooglePay === 'true' ||
-      rawMonobankGooglePay === '1' ||
-      rawMonobankGooglePay === 'yes' ||
-      rawMonobankGooglePay === 'on');
+    isFlagEnabled(readServerEnv('SHOP_MONOBANK_GPAY_ENABLED'));
 
   const enabledProviders: Array<'monobank' | 'stripe'> = [];
   if (monobankCheckoutEnabled) enabledProviders.push('monobank');

--- a/frontend/lib/shop/commercial-policy.ts
+++ b/frontend/lib/shop/commercial-policy.ts
@@ -1,0 +1,73 @@
+export type StandardStorefrontCurrency = 'UAH';
+export type StandardStorefrontShippingCountry = 'UA';
+export type CompatibleCurrency = 'USD' | StandardStorefrontCurrency;
+export type CompatibleCheckoutProvider = 'stripe' | 'monobank';
+export type CompatiblePaymentMethod =
+  | 'stripe_card'
+  | 'monobank_invoice'
+  | 'monobank_google_pay';
+
+export const STANDARD_STOREFRONT_COMMERCIAL_POLICY = {
+  localePolicy: 'content_only',
+  currency: 'UAH',
+  shippingCountry: 'UA',
+  providerEnablement: 'env_runtime_capability',
+  intlFlow: 'untouched',
+  dormantUsd: 'compatibility_only',
+  schemaCleanup: 'deferred',
+} as const;
+
+function normalizeLocaleTag(locale: string | null | undefined): string {
+  const raw = (locale ?? '').trim().toLowerCase();
+  if (!raw) return '';
+  return raw.split(/[-_]/)[0] ?? raw;
+}
+
+export function resolveCurrentStandardStorefrontCurrencyFromLocale(
+  locale: string | null | undefined
+): CompatibleCurrency {
+  const primary = normalizeLocaleTag(locale);
+  return primary === 'uk'
+    ? STANDARD_STOREFRONT_COMMERCIAL_POLICY.currency
+    : 'USD';
+}
+
+export function resolveCurrentStandardStorefrontShippingCountryFromLocale(
+  locale: string | null | undefined
+): StandardStorefrontShippingCountry | null {
+  const primary = normalizeLocaleTag(locale);
+  return primary === 'uk'
+    ? STANDARD_STOREFRONT_COMMERCIAL_POLICY.shippingCountry
+    : null;
+}
+
+export function inferCurrentCheckoutProviderFromMethod(
+  method: CompatiblePaymentMethod | null | undefined
+): CompatibleCheckoutProvider | null {
+  if (method === 'stripe_card') return 'stripe';
+  if (method === 'monobank_invoice' || method === 'monobank_google_pay') {
+    return 'monobank';
+  }
+
+  return null;
+}
+
+export function resolveCurrentCheckoutProviderCandidates(args: {
+  requestedProvider?: CompatibleCheckoutProvider | null;
+  requestedMethod?: CompatiblePaymentMethod | null;
+  currency: CompatibleCurrency;
+}): readonly CompatibleCheckoutProvider[] {
+  const explicitProvider =
+    args.requestedProvider ??
+    inferCurrentCheckoutProviderFromMethod(args.requestedMethod);
+
+  if (explicitProvider) {
+    return [explicitProvider];
+  }
+
+  if (args.currency === STANDARD_STOREFRONT_COMMERCIAL_POLICY.currency) {
+    return ['monobank', 'stripe'];
+  }
+
+  return ['stripe'];
+}

--- a/frontend/lib/shop/commercial-policy.ts
+++ b/frontend/lib/shop/commercial-policy.ts
@@ -17,6 +17,14 @@ export const STANDARD_STOREFRONT_COMMERCIAL_POLICY = {
   schemaCleanup: 'deferred',
 } as const;
 
+export function resolveStandardStorefrontCurrency(): StandardStorefrontCurrency {
+  return STANDARD_STOREFRONT_COMMERCIAL_POLICY.currency;
+}
+
+export function resolveStandardStorefrontShippingCountry(): StandardStorefrontShippingCountry {
+  return STANDARD_STOREFRONT_COMMERCIAL_POLICY.shippingCountry;
+}
+
 function normalizeLocaleTag(locale: string | null | undefined): string {
   const raw = (locale ?? '').trim().toLowerCase();
   if (!raw) return '';

--- a/frontend/lib/shop/commercial-policy.ts
+++ b/frontend/lib/shop/commercial-policy.ts
@@ -29,39 +29,25 @@ export function resolveStandardStorefrontCheckoutProviderCandidates(args: {
   requestedProvider?: CompatibleCheckoutProvider | null;
   requestedMethod?: CompatiblePaymentMethod | null;
 }): readonly CompatibleCheckoutProvider[] {
-  const explicitProvider =
-    args.requestedProvider ??
-    inferCurrentCheckoutProviderFromMethod(args.requestedMethod);
-
-  if (explicitProvider) {
-    return [explicitProvider];
-  }
-
-  return ['monobank', 'stripe'];
-}
-
-function normalizeLocaleTag(locale: string | null | undefined): string {
-  const raw = (locale ?? '').trim().toLowerCase();
-  if (!raw) return '';
-  return raw.split(/[-_]/)[0] ?? raw;
+  return resolveCheckoutProviderCandidatesFromAllowedProviders({
+    allowedProviders: ['monobank', 'stripe'],
+    requestedProvider: args.requestedProvider,
+    requestedMethod: args.requestedMethod,
+  });
 }
 
 export function resolveCurrentStandardStorefrontCurrencyFromLocale(
   locale: string | null | undefined
 ): CompatibleCurrency {
-  const primary = normalizeLocaleTag(locale);
-  return primary === 'uk'
-    ? STANDARD_STOREFRONT_COMMERCIAL_POLICY.currency
-    : 'USD';
+  void locale;
+  return STANDARD_STOREFRONT_COMMERCIAL_POLICY.currency;
 }
 
 export function resolveCurrentStandardStorefrontShippingCountryFromLocale(
   locale: string | null | undefined
 ): StandardStorefrontShippingCountry | null {
-  const primary = normalizeLocaleTag(locale);
-  return primary === 'uk'
-    ? STANDARD_STOREFRONT_COMMERCIAL_POLICY.shippingCountry
-    : null;
+  void locale;
+  return STANDARD_STOREFRONT_COMMERCIAL_POLICY.shippingCountry;
 }
 
 export function inferCurrentCheckoutProviderFromMethod(
@@ -80,17 +66,33 @@ export function resolveCurrentCheckoutProviderCandidates(args: {
   requestedMethod?: CompatiblePaymentMethod | null;
   currency: CompatibleCurrency;
 }): readonly CompatibleCheckoutProvider[] {
-  const explicitProvider =
-    args.requestedProvider ??
-    inferCurrentCheckoutProviderFromMethod(args.requestedMethod);
+  const allowedProviders: readonly CompatibleCheckoutProvider[] =
+    args.currency === STANDARD_STOREFRONT_COMMERCIAL_POLICY.currency
+      ? ['monobank', 'stripe']
+      : ['stripe'];
 
-  if (explicitProvider) {
-    return [explicitProvider];
+  return resolveCheckoutProviderCandidatesFromAllowedProviders({
+    allowedProviders,
+    requestedProvider: args.requestedProvider,
+    requestedMethod: args.requestedMethod,
+  });
+}
+
+function resolveCheckoutProviderCandidatesFromAllowedProviders(args: {
+  allowedProviders: readonly CompatibleCheckoutProvider[];
+  requestedProvider?: CompatibleCheckoutProvider | null;
+  requestedMethod?: CompatiblePaymentMethod | null;
+}): readonly CompatibleCheckoutProvider[] {
+  const inferredProvider = inferCurrentCheckoutProviderFromMethod(
+    args.requestedMethod
+  );
+  const methodFiltered = inferredProvider
+    ? args.allowedProviders.filter(provider => provider === inferredProvider)
+    : [...args.allowedProviders];
+
+  if (!args.requestedProvider) {
+    return methodFiltered;
   }
 
-  if (args.currency === STANDARD_STOREFRONT_COMMERCIAL_POLICY.currency) {
-    return ['monobank', 'stripe'];
-  }
-
-  return ['stripe'];
+  return methodFiltered.filter(provider => provider === args.requestedProvider);
 }

--- a/frontend/lib/shop/commercial-policy.ts
+++ b/frontend/lib/shop/commercial-policy.ts
@@ -25,6 +25,21 @@ export function resolveStandardStorefrontShippingCountry(): StandardStorefrontSh
   return STANDARD_STOREFRONT_COMMERCIAL_POLICY.shippingCountry;
 }
 
+export function resolveStandardStorefrontCheckoutProviderCandidates(args: {
+  requestedProvider?: CompatibleCheckoutProvider | null;
+  requestedMethod?: CompatiblePaymentMethod | null;
+}): readonly CompatibleCheckoutProvider[] {
+  const explicitProvider =
+    args.requestedProvider ??
+    inferCurrentCheckoutProviderFromMethod(args.requestedMethod);
+
+  if (explicitProvider) {
+    return [explicitProvider];
+  }
+
+  return ['monobank', 'stripe'];
+}
+
 function normalizeLocaleTag(locale: string | null | undefined): string {
   const raw = (locale ?? '').trim().toLowerCase();
   if (!raw) return '';

--- a/frontend/lib/shop/currency.ts
+++ b/frontend/lib/shop/currency.ts
@@ -60,6 +60,8 @@ function normalizeLocaleForIntl(
   currency: CurrencyCode
 ): string {
   const raw = (locale ?? '').trim();
+  if (currency === 'UAH') return 'uk-UA';
+
   const primary = normalizeLocaleTag(raw);
 
   if (primary === 'uk') return 'uk-UA';
@@ -67,7 +69,7 @@ function normalizeLocaleForIntl(
 
   if (raw) return raw.replaceAll('_', '-');
 
-  return currency === 'UAH' ? 'uk-UA' : 'en-US';
+  return 'en-US';
 }
 
 const formatterCache = new Map<string, Intl.NumberFormat>();

--- a/frontend/lib/shop/currency.ts
+++ b/frontend/lib/shop/currency.ts
@@ -1,3 +1,5 @@
+import { resolveCurrentStandardStorefrontCurrencyFromLocale } from '@/lib/shop/commercial-policy';
+
 export const currencyValues = ['USD', 'UAH'] as const;
 export type CurrencyCode = (typeof currencyValues)[number];
 
@@ -31,8 +33,7 @@ function normalizeLocaleTag(locale: string | null | undefined): string {
 export function resolveCurrencyFromLocale(
   locale: string | null | undefined
 ): CurrencyCode {
-  const primary = normalizeLocaleTag(locale);
-  return primary === 'uk' ? 'UAH' : 'USD';
+  return resolveCurrentStandardStorefrontCurrencyFromLocale(locale);
 }
 
 export function parsePrimaryLocaleFromAcceptLanguage(

--- a/frontend/lib/shop/data.ts
+++ b/frontend/lib/shop/data.ts
@@ -24,7 +24,7 @@ import {
   shopProductSchema,
 } from '@/lib/validation/shop';
 
-import { resolveCurrencyFromLocale } from './currency';
+import { resolveStandardStorefrontCurrency } from './commercial-policy';
 import { fromDbMoney } from './money';
 
 export type ShopProduct = ValidationShopProduct;
@@ -87,7 +87,8 @@ export async function getProductPageData(
   slug: string,
   locale: string = 'en'
 ): Promise<ProductPageData> {
-  const currency = resolveCurrencyFromLocale(locale);
+  void locale;
+  const currency = resolveStandardStorefrontCurrency();
 
   const dbProduct = await getPublicProductBySlug(slug, currency);
   if (dbProduct) {
@@ -368,7 +369,8 @@ export async function getCatalogProducts(
   const { category, type, color, size, sort, page, limit } =
     validateCatalogFilters(filters);
 
-  const currency = resolveCurrencyFromLocale(locale);
+  void locale;
+  const currency = resolveStandardStorefrontCurrency();
 
   const { items, total } = await getActiveProductsPage({
     currency,
@@ -395,7 +397,8 @@ export async function getProductDetail(
   locale: string = 'en'
 ): Promise<ShopProduct | null> {
   try {
-    const currency = resolveCurrencyFromLocale(locale);
+    void locale;
+    const currency = resolveStandardStorefrontCurrency();
 
     const dbProduct = await getPublicProductBySlug(slug, currency);
 

--- a/frontend/lib/shop/locale.ts
+++ b/frontend/lib/shop/locale.ts
@@ -1,13 +1,9 @@
+import { resolveCurrentStandardStorefrontShippingCountryFromLocale } from '@/lib/shop/commercial-policy';
+
 export function localeToCountry(
   input: string | null | undefined
 ): string | null {
-  const locale = (input ?? '').trim().toLowerCase();
-  if (!locale) return null;
-
-  const primary = locale.split(/[-_]/)[0]?.toLowerCase() ?? '';
-  if (primary === 'uk') return 'UA';
-
-  return null;
+  return resolveCurrentStandardStorefrontShippingCountryFromLocale(input);
 }
 
 export const countryFromLocale = localeToCountry;

--- a/frontend/lib/shop/payments.ts
+++ b/frontend/lib/shop/payments.ts
@@ -1,3 +1,7 @@
+import {
+  inferCurrentCheckoutProviderFromMethod,
+  resolveCurrentCheckoutProviderCandidates,
+} from '@/lib/shop/commercial-policy';
 import type { CurrencyCode } from '@/lib/shop/currency';
 
 export const paymentStatusValues = [
@@ -28,12 +32,7 @@ export type PaymentMethod = (typeof paymentMethodValues)[number];
 export function inferCheckoutProviderFromMethod(
   method: PaymentMethod | null | undefined
 ): CheckoutPaymentProvider | null {
-  if (method === 'stripe_card') return 'stripe';
-  if (method === 'monobank_invoice' || method === 'monobank_google_pay') {
-    return 'monobank';
-  }
-
-  return null;
+  return inferCurrentCheckoutProviderFromMethod(method);
 }
 
 export function resolveCheckoutProviderCandidates(args: {
@@ -41,19 +40,7 @@ export function resolveCheckoutProviderCandidates(args: {
   requestedMethod?: PaymentMethod | null;
   currency: CurrencyCode;
 }): readonly CheckoutPaymentProvider[] {
-  const explicitProvider =
-    args.requestedProvider ??
-    inferCheckoutProviderFromMethod(args.requestedMethod);
-
-  if (explicitProvider) {
-    return [explicitProvider];
-  }
-
-  if (args.currency === 'UAH') {
-    return ['monobank', 'stripe'];
-  }
-
-  return ['stripe'];
+  return resolveCurrentCheckoutProviderCandidates(args);
 }
 
 export function resolveDefaultMethodForProvider(

--- a/frontend/lib/tests/shop/admin-product-form-messages.test.ts
+++ b/frontend/lib/tests/shop/admin-product-form-messages.test.ts
@@ -22,50 +22,31 @@ function getAtPath(
 
 describe('admin product form i18n messages', () => {
   it('keeps product form labels under shop.admin.products.form for all supported locales', () => {
-    for (const messages of [en, uk, pl]) {
-      expect(
-        getAtPath(messages as Record<string, unknown>, [
-          'shop',
-          'admin',
-          'products',
-          'form',
-          'fields',
-          'title',
-        ])
-      ).toBeTruthy();
-
-      expect(
-        getAtPath(messages as Record<string, unknown>, [
-          'shop',
-          'admin',
-          'products',
-          'form',
-          'pricing',
-          'helper',
-        ])
-      ).toBeTruthy();
-
-      expect(
-        getAtPath(messages as Record<string, unknown>, [
+    for (const [locale, messages] of [
+      ['en', en],
+      ['uk', uk],
+      ['pl', pl],
+    ] as const) {
+      for (const path of [
+        ['shop', 'admin', 'products', 'form', 'fields', 'title'],
+        ['shop', 'admin', 'products', 'form', 'pricing', 'helper'],
+        [
           'shop',
           'admin',
           'products',
           'form',
           'errors',
           'legacyPhotoMigrationRequired',
-        ])
-      ).toBeTruthy();
+        ],
+        ['shop', 'admin', 'products', 'form', 'actions', 'save'],
+      ] as const) {
+        const resolved = getAtPath(messages as Record<string, unknown>, path);
 
-      expect(
-        getAtPath(messages as Record<string, unknown>, [
-          'shop',
-          'admin',
-          'products',
-          'form',
-          'actions',
-          'save',
-        ])
-      ).toBeTruthy();
+        expect(
+          resolved,
+          `Missing ${path.join('.')} for locale ${locale}`
+        ).toBeTruthy();
+      }
     }
   });
 });

--- a/frontend/lib/tests/shop/admin-product-form-messages.test.ts
+++ b/frontend/lib/tests/shop/admin-product-form-messages.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import en from '@/messages/en.json';
+import pl from '@/messages/pl.json';
+import uk from '@/messages/uk.json';
+
+function getAtPath(
+  root: Record<string, unknown>,
+  path: readonly string[]
+): unknown {
+  let current: unknown = root;
+
+  for (const segment of path) {
+    if (!current || typeof current !== 'object' || !(segment in current)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+}
+
+describe('admin product form i18n messages', () => {
+  it('keeps product form labels under shop.admin.products.form for all supported locales', () => {
+    for (const messages of [en, uk, pl]) {
+      expect(
+        getAtPath(messages as Record<string, unknown>, [
+          'shop',
+          'admin',
+          'products',
+          'form',
+          'fields',
+          'title',
+        ])
+      ).toBeTruthy();
+
+      expect(
+        getAtPath(messages as Record<string, unknown>, [
+          'shop',
+          'admin',
+          'products',
+          'form',
+          'pricing',
+          'helper',
+        ])
+      ).toBeTruthy();
+
+      expect(
+        getAtPath(messages as Record<string, unknown>, [
+          'shop',
+          'admin',
+          'products',
+          'form',
+          'errors',
+          'legacyPhotoMigrationRequired',
+        ])
+      ).toBeTruthy();
+
+      expect(
+        getAtPath(messages as Record<string, unknown>, [
+          'shop',
+          'admin',
+          'products',
+          'form',
+          'actions',
+          'save',
+        ])
+      ).toBeTruthy();
+    }
+  });
+});

--- a/frontend/lib/tests/shop/admin-product-patch-price-config-error-contract.test.ts
+++ b/frontend/lib/tests/shop/admin-product-patch-price-config-error-contract.test.ts
@@ -29,9 +29,8 @@ vi.mock('@/lib/admin/parseAdminProductForm', () => ({
 
 vi.mock('@/lib/services/products', () => ({
   updateProduct: vi.fn(async () => {
-    throw new PriceConfigError('USD price is required.', {
+    throw new PriceConfigError('At least one price is required.', {
       productId: 'p1',
-      currency: 'USD',
     });
   }),
   getAdminProductByIdWithPrices: vi.fn(),

--- a/frontend/lib/tests/shop/admin-product-patch-price-config-error-contract.test.ts
+++ b/frontend/lib/tests/shop/admin-product-patch-price-config-error-contract.test.ts
@@ -29,8 +29,9 @@ vi.mock('@/lib/admin/parseAdminProductForm', () => ({
 
 vi.mock('@/lib/services/products', () => ({
   updateProduct: vi.fn(async () => {
-    throw new PriceConfigError('At least one price is required.', {
+    throw new PriceConfigError('UAH price is required.', {
       productId: 'p1',
+      currency: 'UAH',
     });
   }),
   getAdminProductByIdWithPrices: vi.fn(),
@@ -59,7 +60,6 @@ function makeReq(): NextRequest {
     'prices',
     JSON.stringify([
       { currency: 'USD', priceMinor: 999, originalPriceMinor: null },
-      { currency: 'UAH', priceMinor: 1000, originalPriceMinor: null },
     ])
   );
 
@@ -84,5 +84,6 @@ describe('admin PATCH /shop/admin/products/:id (PRICE_CONFIG_ERROR contract)', (
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.code).toBe('PRICE_CONFIG_ERROR');
+    expect(json.currency).toBe('UAH');
   });
 });

--- a/frontend/lib/tests/shop/cart-public-provider-policy.test.ts
+++ b/frontend/lib/tests/shop/cart-public-provider-policy.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveDefaultMethodForProvider,
+  resolveInitialProvider,
+} from '@/app/[locale]/shop/cart/provider-policy';
+
+describe('cart public provider policy', () => {
+  it('does not gate initial Monobank selection on cart currency', () => {
+    expect(
+      resolveInitialProvider({
+        stripeEnabled: false,
+        monobankEnabled: true,
+        currency: 'USD',
+      })
+    ).toBe('monobank');
+  });
+
+  it('keeps Monobank payment method selection available even before checkout enforcement switches', () => {
+    expect(
+      resolveDefaultMethodForProvider({
+        provider: 'monobank',
+        currency: 'USD',
+      })
+    ).toBe('monobank_invoice');
+  });
+});

--- a/frontend/lib/tests/shop/cart-public-provider-policy.test.ts
+++ b/frontend/lib/tests/shop/cart-public-provider-policy.test.ts
@@ -16,7 +16,7 @@ describe('cart public provider policy', () => {
     ).toBe('monobank');
   });
 
-  it('keeps Monobank payment method selection available even before checkout enforcement switches', () => {
+  it('keeps Monobank payment method selection available without cart currency gating', () => {
     expect(
       resolveDefaultMethodForProvider({
         provider: 'monobank',

--- a/frontend/lib/tests/shop/cart-rehydrate-route-policy.test.ts
+++ b/frontend/lib/tests/shop/cart-rehydrate-route-policy.test.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rehydrateCartItemsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/services/products', () => ({
+  rehydrateCartItems: (...args: unknown[]) => rehydrateCartItemsMock(...args),
+}));
+
+vi.mock('@/lib/logging', () => ({
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+const { POST } = await import('@/app/api/shop/cart/rehydrate/route');
+
+describe('cart rehydrate route public policy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rehydrateCartItemsMock.mockResolvedValue({
+      items: [],
+      summary: {
+        quantity: 0,
+        totalAmountMinor: 0,
+        currency: 'UAH',
+        pricingFingerprint: 'f'.repeat(64),
+      },
+    });
+  });
+
+  it('rehydrates carts in the standard storefront UAH currency even on en locale requests', async () => {
+    const request = new NextRequest(
+      'http://localhost/api/shop/cart/rehydrate',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept-Language': 'en-US,en;q=0.9',
+        },
+        body: JSON.stringify({
+          items: [],
+        }),
+      }
+    );
+
+    const response = await POST(request);
+    const json: any = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(rehydrateCartItemsMock).toHaveBeenCalledWith([], 'UAH');
+    expect(json.summary.currency).toBe('UAH');
+  });
+});

--- a/frontend/lib/tests/shop/catalog-merchandising-cleanup.test.ts
+++ b/frontend/lib/tests/shop/catalog-merchandising-cleanup.test.ts
@@ -138,7 +138,7 @@ describe('catalog merchandising cleanup', () => {
     const content = await getHomepageContent('en');
 
     expect(shopQueryMocks.getActiveProductsPage).toHaveBeenCalledWith({
-      currency: 'USD',
+      currency: 'UAH',
       limit: 12,
       offset: 0,
       category: undefined,

--- a/frontend/lib/tests/shop/checkout-currency-policy.test.ts
+++ b/frontend/lib/tests/shop/checkout-currency-policy.test.ts
@@ -17,6 +17,7 @@ import {
 } from '@/db/schema';
 import { resetEnvCache } from '@/lib/env';
 import { rehydrateCartItems } from '@/lib/services/products';
+import { TEST_LEGAL_CONSENT } from '@/lib/tests/shop/test-legal-consent';
 
 vi.mock('@/lib/auth', async () => {
   const actual =
@@ -162,6 +163,7 @@ async function makeCheckoutRequest(
     payload && typeof payload === 'object' && !Array.isArray(payload)
       ? ({ ...(payload as Record<string, unknown>) } as Record<string, unknown>)
       : {};
+  body.legalConsent ??= TEST_LEGAL_CONSENT;
   const items = Array.isArray(body.items) ? body.items : [];
   const currency = opts.acceptLanguage.trim().toLowerCase().startsWith('uk')
     ? 'UAH'

--- a/frontend/lib/tests/shop/checkout-currency-policy.test.ts
+++ b/frontend/lib/tests/shop/checkout-currency-policy.test.ts
@@ -165,9 +165,7 @@ async function makeCheckoutRequest(
       : {};
   body.legalConsent ??= TEST_LEGAL_CONSENT;
   const items = Array.isArray(body.items) ? body.items : [];
-  const currency = opts.acceptLanguage.trim().toLowerCase().startsWith('uk')
-    ? 'UAH'
-    : 'USD';
+  const currency = 'UAH';
 
   if (items.length > 0) {
     try {
@@ -275,7 +273,7 @@ describe('P0-CUR-3 checkout currency policy', () => {
     expect(json.order.totalAmount).toBe(100);
   });
 
-  it('locale en -> order.currency USD and totals correct', async () => {
+  it('locale en -> order.currency UAH and totals correct', async () => {
     const slug = `t-en-${crypto.randomUUID()}`;
     const productId = await seedProduct({
       slug,
@@ -303,8 +301,40 @@ describe('P0-CUR-3 checkout currency policy', () => {
     const json = await res.json();
     createdOrderIds.push(json.order.id);
 
-    expect(json.order.currency).toBe('USD');
-    expect(json.order.totalAmount).toBe(67);
+    expect(json.order.currency).toBe('UAH');
+    expect(json.order.totalAmount).toBe(100);
+  });
+
+  it('locale pl -> order.currency UAH and totals correct', async () => {
+    const slug = `t-pl-${crypto.randomUUID()}`;
+    const productId = await seedProduct({
+      slug,
+      title: 'Test Product PL',
+      stock: 10,
+      prices: [
+        { currency: 'USD', priceMinor: 6700, price: '67.00' },
+        { currency: 'UAH', priceMinor: 10000, price: '100.00' },
+      ],
+    });
+
+    const req = await makeCheckoutRequest(
+      {
+        paymentProvider: 'stripe',
+        paymentMethod: 'stripe_card',
+        items: [{ productId, quantity: 1 }],
+      },
+      { idempotencyKey: makeIdempotencyKey(), acceptLanguage: 'pl-PL,pl;q=0.9' }
+    );
+
+    const res = await POST(req);
+    await debugIfNotExpected(res, 201);
+    expect(res.status).toBe(201);
+
+    const json = await res.json();
+    createdOrderIds.push(json.order.id);
+
+    expect(json.order.currency).toBe('UAH');
+    expect(json.order.totalAmount).toBe(100);
   });
 
   it('missing price for currency -> 400 PRICE_CONFIG_ERROR', async () => {

--- a/frontend/lib/tests/shop/checkout-display-currency.test.ts
+++ b/frontend/lib/tests/shop/checkout-display-currency.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveCheckoutDisplayCurrency } from '@/lib/shop/checkout-display-currency';
+
+describe('checkout display currency fallback', () => {
+  it('falls back to standard storefront UAH when checkout display currency is missing or invalid', () => {
+    expect(resolveCheckoutDisplayCurrency(null)).toBe('UAH');
+    expect(resolveCheckoutDisplayCurrency('')).toBe('UAH');
+    expect(resolveCheckoutDisplayCurrency('invalid')).toBe('UAH');
+  });
+
+  it('preserves explicit persisted order currency values for compatibility paths', () => {
+    expect(resolveCheckoutDisplayCurrency('USD')).toBe('USD');
+    expect(resolveCheckoutDisplayCurrency('UAH')).toBe('UAH');
+  });
+});

--- a/frontend/lib/tests/shop/checkout-legal-consent-contract.test.ts
+++ b/frontend/lib/tests/shop/checkout-legal-consent-contract.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { checkoutPayloadSchema } from '@/lib/validation/shop';
 
 describe('checkout legal consent contract', () => {
@@ -25,5 +27,36 @@ describe('checkout legal consent contract', () => {
     });
 
     expect(explicitConsent.success).toBe(true);
+  });
+
+  it('does not infer a provider-derived fallback currency inside the shared checkout schema', () => {
+    const stripeWithoutCurrency = checkoutPayloadSchema.safeParse({
+      ...basePayload,
+      legalConsent: {
+        termsAccepted: true,
+        privacyAccepted: true,
+        termsVersion: 'terms-v1',
+        privacyVersion: 'privacy-v1',
+      },
+      paymentProvider: 'stripe',
+      paymentMethod: 'stripe_card',
+    });
+
+    expect(stripeWithoutCurrency.success).toBe(true);
+
+    const monobankWithWrongCurrency = checkoutPayloadSchema.safeParse({
+      ...basePayload,
+      legalConsent: {
+        termsAccepted: true,
+        privacyAccepted: true,
+        termsVersion: 'terms-v1',
+        privacyVersion: 'privacy-v1',
+      },
+      paymentProvider: 'monobank',
+      paymentMethod: 'monobank_invoice',
+      paymentCurrency: 'USD',
+    });
+
+    expect(monobankWithWrongCurrency.success).toBe(false);
   });
 });

--- a/frontend/lib/tests/shop/checkout-monobank-happy-path.test.ts
+++ b/frontend/lib/tests/shop/checkout-monobank-happy-path.test.ts
@@ -15,8 +15,10 @@ import { db } from '@/db';
 import { orders, paymentAttempts, productPrices, products } from '@/db/schema';
 import { resetEnvCache } from '@/lib/env';
 import { toDbMoney } from '@/lib/shop/money';
+import { rehydrateCartItems } from '@/lib/services/products';
 import { assertNotProductionDb } from '@/lib/tests/helpers/db-safety';
 import { deriveTestIpFromIdemKey } from '@/lib/tests/helpers/ip';
+import { TEST_LEGAL_CONSENT } from '@/lib/tests/shop/test-legal-consent';
 
 vi.mock('@/lib/auth', () => ({
   getCurrentUser: vi.fn().mockResolvedValue(null),
@@ -163,22 +165,25 @@ async function postCheckout(idemKey: string, productId: string) {
   const mod = (await import('@/app/api/shop/checkout/route')) as unknown as {
     POST: (req: NextRequest) => Promise<Response>;
   };
+  const quote = await rehydrateCartItems([{ productId, quantity: 1 }], 'UAH');
 
   const req = new NextRequest('http://localhost/api/shop/checkout', {
     method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      'accept-language': 'uk-UA',
-      'idempotency-key': idemKey,
-      'x-request-id': `mono-happy-${idemKey}`,
-      'x-forwarded-for': deriveTestIpFromIdemKey(idemKey),
-      origin: 'http://localhost:3000',
-    },
-    body: JSON.stringify({
-      items: [{ productId, quantity: 1 }],
-      paymentProvider: 'monobank',
-    }),
-  });
+      headers: {
+        'content-type': 'application/json',
+        'accept-language': 'en-US,en;q=0.9',
+        'idempotency-key': idemKey,
+        'x-request-id': `mono-happy-${idemKey}`,
+        'x-forwarded-for': deriveTestIpFromIdemKey(idemKey),
+        origin: 'http://localhost:3000',
+      },
+      body: JSON.stringify({
+        items: [{ productId, quantity: 1 }],
+        paymentProvider: 'monobank',
+        pricingFingerprint: quote.summary.pricingFingerprint,
+        legalConsent: TEST_LEGAL_CONSENT,
+      }),
+    });
 
   return mod.POST(req);
 }

--- a/frontend/lib/tests/shop/checkout-monobank-idempotency-contract.test.ts
+++ b/frontend/lib/tests/shop/checkout-monobank-idempotency-contract.test.ts
@@ -14,12 +14,14 @@ import {
 import { db } from '@/db';
 import { orders, paymentAttempts, productPrices, products } from '@/db/schema';
 import { resetEnvCache } from '@/lib/env';
+import { rehydrateCartItems } from '@/lib/services/products';
 import { toDbMoney } from '@/lib/shop/money';
 import { deriveTestIpFromIdemKey } from '@/lib/tests/helpers/ip';
 import {
   cleanupSeededTemplateProduct,
   getOrSeedActiveTemplateProduct,
 } from '@/lib/tests/helpers/seed-product';
+import { TEST_LEGAL_CONSENT } from '@/lib/tests/shop/test-legal-consent';
 
 vi.mock('@/lib/auth', () => ({
   getCurrentUser: vi.fn().mockResolvedValue(null),
@@ -177,11 +179,19 @@ type MonobankCheckoutMethod = 'monobank_invoice' | 'monobank_google_pay';
 async function postCheckout(
   idemKey: string,
   productId: string,
-  options?: { paymentMethod?: MonobankCheckoutMethod }
+  options?: {
+    paymentMethod?: MonobankCheckoutMethod;
+    includePricingFingerprint?: boolean;
+  }
 ) {
   const mod = (await import('@/app/api/shop/checkout/route')) as unknown as {
     POST: (req: NextRequest) => Promise<Response>;
   };
+  const pricingFingerprint =
+    options?.includePricingFingerprint === false
+      ? null
+      : (await rehydrateCartItems([{ productId, quantity: 1 }], 'UAH')).summary
+          .pricingFingerprint;
 
   const req = new NextRequest('http://localhost/api/shop/checkout', {
     method: 'POST',
@@ -196,7 +206,9 @@ async function postCheckout(
 
     body: JSON.stringify({
       items: [{ productId, quantity: 1 }],
+      legalConsent: TEST_LEGAL_CONSENT,
       paymentProvider: 'monobank',
+      ...(pricingFingerprint ? { pricingFingerprint } : {}),
       ...(options?.paymentMethod
         ? { paymentMethod: options.paymentMethod }
         : {}),
@@ -349,7 +361,8 @@ describe.sequential('checkout monobank contract', () => {
       });
       expect(first.status).toBe(201);
       const firstJson: any = await first.json();
-      orderId = typeof firstJson.orderId === 'string' ? firstJson.orderId : null;
+      orderId =
+        typeof firstJson.orderId === 'string' ? firstJson.orderId : null;
 
       const second = await postCheckout(idemKey, productId, {
         paymentMethod: 'monobank_google_pay',
@@ -393,7 +406,9 @@ describe.sequential('checkout monobank contract', () => {
     const idemKey = crypto.randomUUID();
 
     try {
-      const res = await postCheckout(idemKey, productId);
+      const res = await postCheckout(idemKey, productId, {
+        includePricingFingerprint: false,
+      });
       expect(res.status).toBe(400);
       const json: any = await res.json();
       expect(json.code).toBe('PRICE_CONFIG_ERROR');

--- a/frontend/lib/tests/shop/checkout-monobank-parse-validation.test.ts
+++ b/frontend/lib/tests/shop/checkout-monobank-parse-validation.test.ts
@@ -15,6 +15,7 @@ import {
   hasStatusTokenScope,
   verifyStatusToken,
 } from '@/lib/shop/status-token';
+import { TEST_LEGAL_CONSENT } from '@/lib/tests/shop/test-legal-consent';
 
 vi.mock('@/lib/auth', () => ({
   getCurrentUser: vi.fn().mockResolvedValue(null),
@@ -94,6 +95,11 @@ function makeMonobankCheckoutReq(params: {
   idempotencyKey?: string;
   body: Record<string, unknown>;
 }) {
+  const body = {
+    legalConsent: TEST_LEGAL_CONSENT,
+    ...params.body,
+  };
+
   const headers = new Headers({
     'content-type': 'application/json',
     'accept-language': 'uk-UA',
@@ -108,7 +114,7 @@ function makeMonobankCheckoutReq(params: {
     new Request('http://localhost:3000/api/shop/checkout', {
       method: 'POST',
       headers,
-      body: JSON.stringify(params.body),
+      body: JSON.stringify(body),
     })
   );
 }

--- a/frontend/lib/tests/shop/checkout-monobank-parse-validation.test.ts
+++ b/frontend/lib/tests/shop/checkout-monobank-parse-validation.test.ts
@@ -25,6 +25,19 @@ vi.mock('@/lib/env/monobank', () => ({
   isMonobankEnabled: () => true,
 }));
 
+vi.mock('@/lib/env/stripe', () => ({
+  isPaymentsEnabled: () => true,
+}));
+
+vi.mock('@/lib/services/orders/payment-attempts', () => ({
+  ensureStripePaymentIntentForOrder: vi.fn(async (args: { orderId: string }) => ({
+    paymentIntentId: `pi_test_${args.orderId}`,
+    clientSecret: `cs_test_${args.orderId}`,
+    attemptId: `attempt_${args.orderId}`,
+    attemptNumber: 1,
+  })),
+}));
+
 vi.mock('@/lib/services/orders', async () => {
   const actual = await vi.importActual<any>('@/lib/services/orders');
   return {
@@ -81,6 +94,8 @@ afterAll(() => {
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.SHOP_MONOBANK_GPAY_ENABLED = 'false';
+  (createOrderWithItems as unknown as MockedFn).mockReset();
+  createMonobankAttemptAndInvoiceMock.mockReset();
   createMonobankAttemptAndInvoiceMock.mockResolvedValue({
     attemptId: 'attempt_mono_scope_1',
     attemptNumber: 1,
@@ -94,6 +109,7 @@ beforeEach(() => {
 function makeMonobankCheckoutReq(params: {
   idempotencyKey?: string;
   body: Record<string, unknown>;
+  acceptLanguage?: string;
 }) {
   const body = {
     legalConsent: TEST_LEGAL_CONSENT,
@@ -102,7 +118,7 @@ function makeMonobankCheckoutReq(params: {
 
   const headers = new Headers({
     'content-type': 'application/json',
-    'accept-language': 'uk-UA',
+    'accept-language': params.acceptLanguage ?? 'uk-UA',
     origin: 'http://localhost:3000',
   });
 
@@ -204,7 +220,7 @@ describe('checkout monobank parse/validation', () => {
     expect(Array.isArray(args?.items)).toBe(true);
   });
 
-  it('omitted provider resolves to the server-preferred monobank rail for UAH checkout', async () => {
+  it('omitted provider resolves to the server-preferred monobank rail on en locale too', async () => {
     const createOrderWithItemsMock =
       createOrderWithItems as unknown as MockedFn;
     mockCreateOrderSuccess(createOrderWithItemsMock, 'order_stripe_default_1');
@@ -212,6 +228,7 @@ describe('checkout monobank parse/validation', () => {
     const res = await POST(
       makeMonobankCheckoutReq({
         idempotencyKey: 'stripe_idem_method_0001',
+        acceptLanguage: 'en-US,en;q=0.9',
         body: {
           items: [
             { productId: '11111111-1111-4111-8111-111111111111', quantity: 1 },
@@ -224,6 +241,36 @@ describe('checkout monobank parse/validation', () => {
     const args = createOrderWithItemsMock.mock.calls[0]?.[0];
     expect(args?.paymentProvider).toBe('monobank');
     expect(args?.paymentMethod).toBe('monobank_invoice');
+  });
+
+  it('explicit stripe rail remains available on pl locale when enabled', async () => {
+    const createOrderWithItemsMock =
+      createOrderWithItems as unknown as MockedFn;
+    mockCreateOrderSuccess(createOrderWithItemsMock, 'order_stripe_pl_1', {
+      currency: 'UAH',
+      paymentProvider: 'stripe',
+      paymentStatus: 'pending',
+      paymentIntentId: null,
+    });
+
+    const res = await POST(
+      makeMonobankCheckoutReq({
+        idempotencyKey: 'stripe_pl_enabled_0001',
+        acceptLanguage: 'pl-PL,pl;q=0.9',
+        body: {
+          paymentProvider: 'stripe',
+          paymentMethod: 'stripe_card',
+          items: [
+            { productId: '11111111-1111-4111-8111-111111111111', quantity: 1 },
+          ],
+        },
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const args = createOrderWithItemsMock.mock.calls[0]?.[0];
+    expect(args?.paymentProvider).toBe('stripe');
+    expect(args?.paymentMethod).toBe('stripe_card');
   });
 
   it('rejects incompatible provider/method pair', async () => {

--- a/frontend/lib/tests/shop/checkout-no-payments.test.ts
+++ b/frontend/lib/tests/shop/checkout-no-payments.test.ts
@@ -8,6 +8,7 @@ import { orders, productPrices, products } from '@/db/schema';
 import { toDbMoney } from '@/lib/shop/money';
 import { deriveTestIpFromIdemKey } from '@/lib/tests/helpers/ip';
 import { getOrSeedActiveTemplateProduct } from '@/lib/tests/helpers/seed-product';
+import { TEST_LEGAL_CONSENT } from '@/lib/tests/shop/test-legal-consent';
 
 const __prevRateLimitDisabled = process.env.RATE_LIMIT_DISABLED;
 
@@ -176,6 +177,7 @@ async function postCheckout(params: {
 
     body: JSON.stringify({
       items: params.items,
+      legalConsent: TEST_LEGAL_CONSENT,
       ...(params.paymentProvider
         ? { paymentProvider: params.paymentProvider }
         : {}),

--- a/frontend/lib/tests/shop/checkout-stripe-payments-disabled.test.ts
+++ b/frontend/lib/tests/shop/checkout-stripe-payments-disabled.test.ts
@@ -21,8 +21,8 @@ import {
   products,
 } from '@/db/schema';
 import { resetEnvCache } from '@/lib/env';
-import { toDbMoney } from '@/lib/shop/money';
 import { rehydrateCartItems } from '@/lib/services/products';
+import { toDbMoney } from '@/lib/shop/money';
 import { deriveTestIpFromIdemKey } from '@/lib/tests/helpers/ip';
 import { getOrSeedActiveTemplateProduct } from '@/lib/tests/helpers/seed-product';
 import { TEST_LEGAL_CONSENT } from '@/lib/tests/shop/test-legal-consent';
@@ -381,7 +381,6 @@ describe.sequential('checkout stripe fail-closed + tamper guards', () => {
           paymentProvider: 'stripe',
           paymentMethod: 'stripe_card',
           paymentCurrency: 'UAH',
-          legalConsent: TEST_LEGAL_CONSENT,
           items: [{ productId, quantity: 1 }],
         },
       });

--- a/frontend/lib/tests/shop/checkout-stripe-payments-disabled.test.ts
+++ b/frontend/lib/tests/shop/checkout-stripe-payments-disabled.test.ts
@@ -22,8 +22,10 @@ import {
 } from '@/db/schema';
 import { resetEnvCache } from '@/lib/env';
 import { toDbMoney } from '@/lib/shop/money';
+import { rehydrateCartItems } from '@/lib/services/products';
 import { deriveTestIpFromIdemKey } from '@/lib/tests/helpers/ip';
 import { getOrSeedActiveTemplateProduct } from '@/lib/tests/helpers/seed-product';
+import { TEST_LEGAL_CONSENT } from '@/lib/tests/shop/test-legal-consent';
 
 vi.mock('@/lib/auth', () => ({
   getCurrentUser: vi.fn().mockResolvedValue(null),
@@ -203,6 +205,16 @@ async function postCheckout(args: {
   const mod = (await import('@/app/api/shop/checkout/route')) as unknown as {
     POST: (req: NextRequest) => Promise<Response>;
   };
+  const items = Array.isArray(args.body.items)
+    ? (args.body.items as Array<{
+        productId: string;
+        quantity: number;
+        selectedSize?: string;
+        selectedColor?: string;
+      }>)
+    : [];
+  const quote =
+    items.length > 0 ? await rehydrateCartItems(items, 'UAH') : null;
 
   const req = new NextRequest('http://localhost/api/shop/checkout', {
     method: 'POST',
@@ -214,7 +226,13 @@ async function postCheckout(args: {
       'x-forwarded-for': deriveTestIpFromIdemKey(args.idemKey),
       origin: 'http://localhost:3000',
     },
-    body: JSON.stringify(args.body),
+    body: JSON.stringify({
+      legalConsent: TEST_LEGAL_CONSENT,
+      ...(quote
+        ? { pricingFingerprint: quote.summary.pricingFingerprint }
+        : {}),
+      ...args.body,
+    }),
   });
 
   return mod.POST(req);
@@ -363,6 +381,7 @@ describe.sequential('checkout stripe fail-closed + tamper guards', () => {
           paymentProvider: 'stripe',
           paymentMethod: 'stripe_card',
           paymentCurrency: 'UAH',
+          legalConsent: TEST_LEGAL_CONSENT,
           items: [{ productId, quantity: 1 }],
         },
       });
@@ -370,8 +389,8 @@ describe.sequential('checkout stripe fail-closed + tamper guards', () => {
       expect(res.status).toBe(201);
       const json: any = await res.json();
       expect(json?.order?.paymentProvider).toBe('stripe');
-      expect(json?.order?.currency).toBe('USD');
-      expect(json?.order?.totalAmount).toBe(67);
+      expect(json?.order?.currency).toBe('UAH');
+      expect(json?.order?.totalAmount).toBe(100);
       expect(typeof json?.clientSecret).toBe('string');
 
       const [row] = await db
@@ -387,8 +406,8 @@ describe.sequential('checkout stripe fail-closed + tamper guards', () => {
         .limit(1);
 
       expect(row).toBeTruthy();
-      expect(row?.currency).toBe('USD');
-      expect(row?.totalAmountMinor).toBe(6700);
+      expect(row?.currency).toBe('UAH');
+      expect(row?.totalAmountMinor).toBe(10000);
       expect(row?.paymentProvider).toBe('stripe');
       expect(row?.paymentStatus).toBe('pending');
       createdOrderId = row?.id ?? null;

--- a/frontend/lib/tests/shop/commercial-policy-delegation.test.ts
+++ b/frontend/lib/tests/shop/commercial-policy-delegation.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('commercial policy wrapper delegation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('currency and locale helpers delegate to the centralized policy module', async () => {
+    const currencyDelegate = vi.fn(() => 'USD');
+    const countryDelegate = vi.fn(() => 'UA');
+
+    vi.doMock('@/lib/shop/commercial-policy', async () => {
+      const actual = await vi.importActual<any>('@/lib/shop/commercial-policy');
+      return {
+        ...actual,
+        resolveCurrentStandardStorefrontCurrencyFromLocale: currencyDelegate,
+        resolveCurrentStandardStorefrontShippingCountryFromLocale:
+          countryDelegate,
+      };
+    });
+
+    const currencyMod = await import('@/lib/shop/currency');
+    const localeMod = await import('@/lib/shop/locale');
+
+    expect(currencyMod.resolveCurrencyFromLocale('uk')).toBe('USD');
+    expect(currencyDelegate).toHaveBeenCalledWith('uk');
+
+    expect(localeMod.localeToCountry('uk')).toBe('UA');
+    expect(countryDelegate).toHaveBeenCalledWith('uk');
+  });
+
+  it('checkout provider helper delegates to the centralized policy module', async () => {
+    const candidateDelegate = vi.fn(() => ['stripe'] as const);
+
+    vi.doMock('@/lib/shop/commercial-policy', async () => {
+      const actual = await vi.importActual<any>('@/lib/shop/commercial-policy');
+      return {
+        ...actual,
+        resolveCurrentCheckoutProviderCandidates: candidateDelegate,
+      };
+    });
+
+    const paymentsMod = await import('@/lib/shop/payments');
+
+    expect(
+      paymentsMod.resolveCheckoutProviderCandidates({
+        currency: 'UAH',
+      })
+    ).toEqual(['stripe']);
+    expect(candidateDelegate).toHaveBeenCalledWith({
+      currency: 'UAH',
+    });
+  });
+
+  it('cart capability helpers delegate to the centralized server policy module', async () => {
+    const resolveCapabilities = vi.fn(() => ({
+      stripeCheckoutEnabled: true,
+      monobankCheckoutEnabled: false,
+      monobankGooglePayEnabled: false,
+      enabledProviders: ['stripe'] as const,
+    }));
+
+    vi.doMock('@/lib/shop/commercial-policy.server', () => ({
+      resolveStandardStorefrontProviderCapabilities: resolveCapabilities,
+    }));
+
+    const mod = await import('@/app/[locale]/shop/cart/capabilities');
+
+    expect(mod.resolveStripeCheckoutEnabled()).toBe(true);
+    expect(mod.resolveMonobankCheckoutEnabled()).toBe(false);
+    expect(mod.resolveMonobankGooglePayEnabled()).toBe(false);
+    expect(resolveCapabilities).toHaveBeenCalledTimes(3);
+  });
+});

--- a/frontend/lib/tests/shop/commercial-policy-delegation.test.ts
+++ b/frontend/lib/tests/shop/commercial-policy-delegation.test.ts
@@ -1,17 +1,28 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const COMMERCIAL_POLICY_MODULE_ID = '@/lib/shop/commercial-policy';
+const COMMERCIAL_POLICY_SERVER_MODULE_ID =
+  '@/lib/shop/commercial-policy.server';
 
 describe('commercial policy wrapper delegation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    vi.doUnmock(COMMERCIAL_POLICY_MODULE_ID);
+    vi.doUnmock(COMMERCIAL_POLICY_SERVER_MODULE_ID);
+  });
+
+  afterEach(() => {
+    vi.doUnmock(COMMERCIAL_POLICY_MODULE_ID);
+    vi.doUnmock(COMMERCIAL_POLICY_SERVER_MODULE_ID);
   });
 
   it('currency and locale helpers delegate to the centralized policy module', async () => {
     const currencyDelegate = vi.fn(() => 'USD');
     const countryDelegate = vi.fn(() => 'UA');
 
-    vi.doMock('@/lib/shop/commercial-policy', async () => {
-      const actual = await vi.importActual<any>('@/lib/shop/commercial-policy');
+    vi.doMock(COMMERCIAL_POLICY_MODULE_ID, async () => {
+      const actual = await vi.importActual<any>(COMMERCIAL_POLICY_MODULE_ID);
       return {
         ...actual,
         resolveCurrentStandardStorefrontCurrencyFromLocale: currencyDelegate,
@@ -33,8 +44,8 @@ describe('commercial policy wrapper delegation', () => {
   it('checkout provider helper delegates to the centralized policy module', async () => {
     const candidateDelegate = vi.fn(() => ['stripe'] as const);
 
-    vi.doMock('@/lib/shop/commercial-policy', async () => {
-      const actual = await vi.importActual<any>('@/lib/shop/commercial-policy');
+    vi.doMock(COMMERCIAL_POLICY_MODULE_ID, async () => {
+      const actual = await vi.importActual<any>(COMMERCIAL_POLICY_MODULE_ID);
       return {
         ...actual,
         resolveCurrentCheckoutProviderCandidates: candidateDelegate,
@@ -61,7 +72,7 @@ describe('commercial policy wrapper delegation', () => {
       enabledProviders: ['stripe'] as const,
     }));
 
-    vi.doMock('@/lib/shop/commercial-policy.server', () => ({
+    vi.doMock(COMMERCIAL_POLICY_SERVER_MODULE_ID, () => ({
       resolveStandardStorefrontProviderCapabilities: resolveCapabilities,
     }));
 

--- a/frontend/lib/tests/shop/commercial-policy.test.ts
+++ b/frontend/lib/tests/shop/commercial-policy.test.ts
@@ -5,6 +5,7 @@ import {
   resolveCurrentCheckoutProviderCandidates,
   resolveCurrentStandardStorefrontCurrencyFromLocale,
   resolveCurrentStandardStorefrontShippingCountryFromLocale,
+  resolveStandardStorefrontCheckoutProviderCandidates,
   STANDARD_STOREFRONT_COMMERCIAL_POLICY,
 } from '@/lib/shop/commercial-policy';
 
@@ -77,5 +78,22 @@ describe('commercial policy contract', () => {
         currency: 'UAH',
       })
     ).toEqual(['stripe']);
+  });
+
+  it('resolves standard storefront checkout provider candidates without locale-derived currency input', () => {
+    expect(resolveStandardStorefrontCheckoutProviderCandidates({})).toEqual([
+      'monobank',
+      'stripe',
+    ]);
+    expect(
+      resolveStandardStorefrontCheckoutProviderCandidates({
+        requestedProvider: 'stripe',
+      })
+    ).toEqual(['stripe']);
+    expect(
+      resolveStandardStorefrontCheckoutProviderCandidates({
+        requestedMethod: 'monobank_invoice',
+      })
+    ).toEqual(['monobank']);
   });
 });

--- a/frontend/lib/tests/shop/commercial-policy.test.ts
+++ b/frontend/lib/tests/shop/commercial-policy.test.ts
@@ -22,7 +22,7 @@ describe('commercial policy contract', () => {
     });
   });
 
-  it('keeps current locale-based storefront currency compatibility unchanged', () => {
+  it('returns the standard storefront currency regardless of locale wrapper input', () => {
     expect(resolveCurrentStandardStorefrontCurrencyFromLocale('uk')).toBe(
       'UAH'
     );
@@ -30,17 +30,17 @@ describe('commercial policy contract', () => {
       'UAH'
     );
     expect(resolveCurrentStandardStorefrontCurrencyFromLocale('en')).toBe(
-      'USD'
+      'UAH'
     );
     expect(resolveCurrentStandardStorefrontCurrencyFromLocale('pl-PL')).toBe(
-      'USD'
+      'UAH'
     );
     expect(resolveCurrentStandardStorefrontCurrencyFromLocale(null)).toBe(
-      'USD'
+      'UAH'
     );
   });
 
-  it('keeps current locale-based shipping country compatibility unchanged', () => {
+  it('returns the standard storefront shipping country regardless of locale wrapper input', () => {
     expect(
       resolveCurrentStandardStorefrontShippingCountryFromLocale('uk')
     ).toBe('UA');
@@ -49,13 +49,13 @@ describe('commercial policy contract', () => {
     ).toBe('UA');
     expect(
       resolveCurrentStandardStorefrontShippingCountryFromLocale('en')
-    ).toBe(null);
+    ).toBe('UA');
     expect(
       resolveCurrentStandardStorefrontShippingCountryFromLocale(null)
-    ).toBe(null);
+    ).toBe('UA');
   });
 
-  it('keeps current checkout provider candidate compatibility unchanged', () => {
+  it('tightens the currency-aware checkout provider helper against contradictory provider and method input', () => {
     expect(inferCurrentCheckoutProviderFromMethod('stripe_card')).toBe(
       'stripe'
     );
@@ -78,9 +78,28 @@ describe('commercial policy contract', () => {
         currency: 'UAH',
       })
     ).toEqual(['stripe']);
+    expect(
+      resolveCurrentCheckoutProviderCandidates({
+        requestedProvider: 'monobank',
+        currency: 'USD',
+      })
+    ).toEqual([]);
+    expect(
+      resolveCurrentCheckoutProviderCandidates({
+        requestedMethod: 'monobank_invoice',
+        currency: 'USD',
+      })
+    ).toEqual([]);
+    expect(
+      resolveCurrentCheckoutProviderCandidates({
+        requestedProvider: 'stripe',
+        requestedMethod: 'stripe_card',
+        currency: 'USD',
+      })
+    ).toEqual(['stripe']);
   });
 
-  it('resolves standard storefront checkout provider candidates without locale-derived currency input', () => {
+  it('tightens the standard storefront checkout provider helper against contradictory provider and method input', () => {
     expect(resolveStandardStorefrontCheckoutProviderCandidates({})).toEqual([
       'monobank',
       'stripe',
@@ -95,5 +114,11 @@ describe('commercial policy contract', () => {
         requestedMethod: 'monobank_invoice',
       })
     ).toEqual(['monobank']);
+    expect(
+      resolveStandardStorefrontCheckoutProviderCandidates({
+        requestedProvider: 'stripe',
+        requestedMethod: 'monobank_invoice',
+      })
+    ).toEqual([]);
   });
 });

--- a/frontend/lib/tests/shop/commercial-policy.test.ts
+++ b/frontend/lib/tests/shop/commercial-policy.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  inferCurrentCheckoutProviderFromMethod,
+  resolveCurrentCheckoutProviderCandidates,
+  resolveCurrentStandardStorefrontCurrencyFromLocale,
+  resolveCurrentStandardStorefrontShippingCountryFromLocale,
+  STANDARD_STOREFRONT_COMMERCIAL_POLICY,
+} from '@/lib/shop/commercial-policy';
+
+describe('commercial policy contract', () => {
+  it('encodes the Batch CP-01 standard storefront target policy in one place', () => {
+    expect(STANDARD_STOREFRONT_COMMERCIAL_POLICY).toEqual({
+      localePolicy: 'content_only',
+      currency: 'UAH',
+      shippingCountry: 'UA',
+      providerEnablement: 'env_runtime_capability',
+      intlFlow: 'untouched',
+      dormantUsd: 'compatibility_only',
+      schemaCleanup: 'deferred',
+    });
+  });
+
+  it('keeps current locale-based storefront currency compatibility unchanged', () => {
+    expect(resolveCurrentStandardStorefrontCurrencyFromLocale('uk')).toBe(
+      'UAH'
+    );
+    expect(resolveCurrentStandardStorefrontCurrencyFromLocale('uk-UA')).toBe(
+      'UAH'
+    );
+    expect(resolveCurrentStandardStorefrontCurrencyFromLocale('en')).toBe(
+      'USD'
+    );
+    expect(resolveCurrentStandardStorefrontCurrencyFromLocale('pl-PL')).toBe(
+      'USD'
+    );
+    expect(resolveCurrentStandardStorefrontCurrencyFromLocale(null)).toBe(
+      'USD'
+    );
+  });
+
+  it('keeps current locale-based shipping country compatibility unchanged', () => {
+    expect(
+      resolveCurrentStandardStorefrontShippingCountryFromLocale('uk')
+    ).toBe('UA');
+    expect(
+      resolveCurrentStandardStorefrontShippingCountryFromLocale('uk-UA')
+    ).toBe('UA');
+    expect(
+      resolveCurrentStandardStorefrontShippingCountryFromLocale('en')
+    ).toBe(null);
+    expect(
+      resolveCurrentStandardStorefrontShippingCountryFromLocale(null)
+    ).toBe(null);
+  });
+
+  it('keeps current checkout provider candidate compatibility unchanged', () => {
+    expect(inferCurrentCheckoutProviderFromMethod('stripe_card')).toBe(
+      'stripe'
+    );
+    expect(inferCurrentCheckoutProviderFromMethod('monobank_invoice')).toBe(
+      'monobank'
+    );
+    expect(
+      resolveCurrentCheckoutProviderCandidates({
+        currency: 'UAH',
+      })
+    ).toEqual(['monobank', 'stripe']);
+    expect(
+      resolveCurrentCheckoutProviderCandidates({
+        currency: 'USD',
+      })
+    ).toEqual(['stripe']);
+    expect(
+      resolveCurrentCheckoutProviderCandidates({
+        requestedMethod: 'stripe_card',
+        currency: 'UAH',
+      })
+    ).toEqual(['stripe']);
+  });
+});

--- a/frontend/lib/tests/shop/currency.test.ts
+++ b/frontend/lib/tests/shop/currency.test.ts
@@ -9,23 +9,20 @@ import {
   resolveCurrencyFromLocale,
 } from '../../shop/currency';
 
-describe('legacy locale currency compatibility helper', () => {
-  it('maps uk locales to UAH for compatibility resolution', () => {
+describe('standard storefront locale wrappers', () => {
+  it('resolves storefront currency as UAH regardless of locale input', () => {
     expect(resolveCurrencyFromLocale('uk')).toBe('UAH');
     expect(resolveCurrencyFromLocale('uk-UA')).toBe('UAH');
     expect(resolveCurrencyFromLocale('uk_UA')).toBe('UAH');
     expect(resolveCurrencyFromLocale('UK-ua')).toBe('UAH');
+    expect(resolveCurrencyFromLocale('en')).toBe('UAH');
+    expect(resolveCurrencyFromLocale('pl-PL')).toBe('UAH');
+    expect(resolveCurrencyFromLocale(null)).toBe('UAH');
+    expect(resolveCurrencyFromLocale(undefined)).toBe('UAH');
+    expect(resolveCurrencyFromLocale('')).toBe('UAH');
   });
 
-  it('maps non-uk locales to USD for compatibility resolution', () => {
-    expect(resolveCurrencyFromLocale('en')).toBe('USD');
-    expect(resolveCurrencyFromLocale('pl-PL')).toBe('USD');
-    expect(resolveCurrencyFromLocale(null)).toBe('USD');
-    expect(resolveCurrencyFromLocale(undefined)).toBe('USD');
-    expect(resolveCurrencyFromLocale('')).toBe('USD');
-  });
-
-  it('parses the primary locale from Accept-Language for compatibility helpers', () => {
+  it('parses the primary locale from Accept-Language', () => {
     expect(
       parsePrimaryLocaleFromAcceptLanguage('uk-UA,uk;q=0.9,en-US;q=0.8')
     ).toBe('uk-UA');
@@ -34,17 +31,17 @@ describe('legacy locale currency compatibility helper', () => {
     expect(parsePrimaryLocaleFromAcceptLanguage(null)).toBe(null);
   });
 
-  it('resolves locale-derived compatibility currency from Accept-Language headers', () => {
+  it('resolves storefront currency as UAH from Accept-Language headers too', () => {
     const h1 = new Headers({
       'accept-language': 'uk-UA,uk;q=0.9,en-US;q=0.8',
     });
     expect(resolveCurrencyFromHeaders(h1)).toBe('UAH');
 
     const h2 = new Headers({ 'accept-language': 'en-US,en;q=0.9' });
-    expect(resolveCurrencyFromHeaders(h2)).toBe('USD');
+    expect(resolveCurrencyFromHeaders(h2)).toBe('UAH');
 
     const h3 = new Headers();
-    expect(resolveCurrencyFromHeaders(h3)).toBe('USD');
+    expect(resolveCurrencyFromHeaders(h3)).toBe('UAH');
   });
 });
 

--- a/frontend/lib/tests/shop/currency.test.ts
+++ b/frontend/lib/tests/shop/currency.test.ts
@@ -57,7 +57,11 @@ describe('UAH storefront formatting', () => {
     const canonical = formatMoney(200000, 'UAH', canonicalLocale);
 
     for (const locale of otherLocales) {
-      expect(formatMoney(200000, 'UAH', locale)).toBe(canonical);
+      const result = formatMoney(200000, 'UAH', locale);
+      expect(
+        result,
+        `formatMoney should match canonical for locale "${locale}"`
+      ).toBe(canonical);
     }
 
     expect(normalizeRenderedSpacing(canonical)).toBe('2 000,00 ₴');
@@ -68,7 +72,11 @@ describe('UAH storefront formatting', () => {
     const canonical = formatMoneyCode(200000, 'UAH', canonicalLocale);
 
     for (const locale of otherLocales) {
-      expect(formatMoneyCode(200000, 'UAH', locale)).toBe(canonical);
+      const result = formatMoneyCode(200000, 'UAH', locale);
+      expect(
+        result,
+        `formatMoneyCode should match canonical for locale "${locale}"`
+      ).toBe(canonical);
     }
 
     expect(normalizeRenderedSpacing(canonical)).toBe('2 000,00 UAH');
@@ -82,11 +90,13 @@ describe('UAH storefront formatting', () => {
     });
 
     for (const locale of otherLocales) {
+      const result = formatPrice(2000, {
+        currency: 'UAH',
+        locale,
+      });
       expect(
-        formatPrice(2000, {
-          currency: 'UAH',
-          locale,
-        })
+        result,
+        `formatPrice should match canonical for locale "${locale}"`
       ).toBe(canonical);
     }
 

--- a/frontend/lib/tests/shop/currency.test.ts
+++ b/frontend/lib/tests/shop/currency.test.ts
@@ -1,20 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatMoney,
+  formatMoneyCode,
+  formatPrice,
   parsePrimaryLocaleFromAcceptLanguage,
   resolveCurrencyFromHeaders,
   resolveCurrencyFromLocale,
 } from '../../shop/currency';
 
-describe('currency policy (CUR-0 / D1)', () => {
-  it('uk -> UAH', () => {
+describe('legacy locale currency compatibility helper', () => {
+  it('maps uk locales to UAH for compatibility resolution', () => {
     expect(resolveCurrencyFromLocale('uk')).toBe('UAH');
     expect(resolveCurrencyFromLocale('uk-UA')).toBe('UAH');
     expect(resolveCurrencyFromLocale('uk_UA')).toBe('UAH');
     expect(resolveCurrencyFromLocale('UK-ua')).toBe('UAH');
   });
 
-  it('non-uk -> USD', () => {
+  it('maps non-uk locales to USD for compatibility resolution', () => {
     expect(resolveCurrencyFromLocale('en')).toBe('USD');
     expect(resolveCurrencyFromLocale('pl-PL')).toBe('USD');
     expect(resolveCurrencyFromLocale(null)).toBe('USD');
@@ -22,7 +25,7 @@ describe('currency policy (CUR-0 / D1)', () => {
     expect(resolveCurrencyFromLocale('')).toBe('USD');
   });
 
-  it('parses primary locale from Accept-Language', () => {
+  it('parses the primary locale from Accept-Language for compatibility helpers', () => {
     expect(
       parsePrimaryLocaleFromAcceptLanguage('uk-UA,uk;q=0.9,en-US;q=0.8')
     ).toBe('uk-UA');
@@ -31,7 +34,7 @@ describe('currency policy (CUR-0 / D1)', () => {
     expect(parsePrimaryLocaleFromAcceptLanguage(null)).toBe(null);
   });
 
-  it('resolves from headers only (Accept-Language)', () => {
+  it('resolves locale-derived compatibility currency from Accept-Language headers', () => {
     const h1 = new Headers({
       'accept-language': 'uk-UA,uk;q=0.9,en-US;q=0.8',
     });
@@ -42,5 +45,41 @@ describe('currency policy (CUR-0 / D1)', () => {
 
     const h3 = new Headers();
     expect(resolveCurrencyFromHeaders(h3)).toBe('USD');
+  });
+});
+
+function normalizeRenderedSpacing(value: string): string {
+  return value.replace(/\s+/gu, ' ').trim();
+}
+
+describe('UAH storefront formatting', () => {
+  it('formats UAH identically across uk / en / pl in Ukrainian storefront style', () => {
+    const uk = formatMoney(200000, 'UAH', 'uk');
+    const en = formatMoney(200000, 'UAH', 'en');
+    const pl = formatMoney(200000, 'UAH', 'pl');
+
+    expect(en).toBe(uk);
+    expect(pl).toBe(uk);
+    expect(normalizeRenderedSpacing(uk)).toBe('2 000,00 ₴');
+  });
+
+  it('formats UAH code output identically across uk / en / pl', () => {
+    const uk = formatMoneyCode(200000, 'UAH', 'uk');
+    const en = formatMoneyCode(200000, 'UAH', 'en');
+    const pl = formatMoneyCode(200000, 'UAH', 'pl');
+
+    expect(en).toBe(uk);
+    expect(pl).toBe(uk);
+    expect(normalizeRenderedSpacing(uk)).toBe('2 000,00 UAH');
+  });
+
+  it('formats major-unit UAH prices identically across uk / en / pl', () => {
+    const uk = formatPrice(2000, { currency: 'UAH', locale: 'uk' });
+    const en = formatPrice(2000, { currency: 'UAH', locale: 'en' });
+    const pl = formatPrice(2000, { currency: 'UAH', locale: 'pl' });
+
+    expect(en).toBe(uk);
+    expect(pl).toBe(uk);
+    expect(normalizeRenderedSpacing(uk)).toBe('2 000,00 ₴');
   });
 });

--- a/frontend/lib/tests/shop/currency.test.ts
+++ b/frontend/lib/tests/shop/currency.test.ts
@@ -9,6 +9,8 @@ import {
   resolveCurrencyFromLocale,
 } from '../../shop/currency';
 
+const STOREFRONT_LOCALES = ['uk', 'en', 'pl'] as const;
+
 describe('standard storefront locale wrappers', () => {
   it('resolves storefront currency as UAH regardless of locale input', () => {
     expect(resolveCurrencyFromLocale('uk')).toBe('UAH');
@@ -51,32 +53,43 @@ function normalizeRenderedSpacing(value: string): string {
 
 describe('UAH storefront formatting', () => {
   it('formats UAH identically across uk / en / pl in Ukrainian storefront style', () => {
-    const uk = formatMoney(200000, 'UAH', 'uk');
-    const en = formatMoney(200000, 'UAH', 'en');
-    const pl = formatMoney(200000, 'UAH', 'pl');
+    const [canonicalLocale, ...otherLocales] = STOREFRONT_LOCALES;
+    const canonical = formatMoney(200000, 'UAH', canonicalLocale);
 
-    expect(en).toBe(uk);
-    expect(pl).toBe(uk);
-    expect(normalizeRenderedSpacing(uk)).toBe('2 000,00 ₴');
+    for (const locale of otherLocales) {
+      expect(formatMoney(200000, 'UAH', locale)).toBe(canonical);
+    }
+
+    expect(normalizeRenderedSpacing(canonical)).toBe('2 000,00 ₴');
   });
 
   it('formats UAH code output identically across uk / en / pl', () => {
-    const uk = formatMoneyCode(200000, 'UAH', 'uk');
-    const en = formatMoneyCode(200000, 'UAH', 'en');
-    const pl = formatMoneyCode(200000, 'UAH', 'pl');
+    const [canonicalLocale, ...otherLocales] = STOREFRONT_LOCALES;
+    const canonical = formatMoneyCode(200000, 'UAH', canonicalLocale);
 
-    expect(en).toBe(uk);
-    expect(pl).toBe(uk);
-    expect(normalizeRenderedSpacing(uk)).toBe('2 000,00 UAH');
+    for (const locale of otherLocales) {
+      expect(formatMoneyCode(200000, 'UAH', locale)).toBe(canonical);
+    }
+
+    expect(normalizeRenderedSpacing(canonical)).toBe('2 000,00 UAH');
   });
 
   it('formats major-unit UAH prices identically across uk / en / pl', () => {
-    const uk = formatPrice(2000, { currency: 'UAH', locale: 'uk' });
-    const en = formatPrice(2000, { currency: 'UAH', locale: 'en' });
-    const pl = formatPrice(2000, { currency: 'UAH', locale: 'pl' });
+    const [canonicalLocale, ...otherLocales] = STOREFRONT_LOCALES;
+    const canonical = formatPrice(2000, {
+      currency: 'UAH',
+      locale: canonicalLocale,
+    });
 
-    expect(en).toBe(uk);
-    expect(pl).toBe(uk);
-    expect(normalizeRenderedSpacing(uk)).toBe('2 000,00 ₴');
+    for (const locale of otherLocales) {
+      expect(
+        formatPrice(2000, {
+          currency: 'UAH',
+          locale,
+        })
+      ).toBe(canonical);
+    }
+
+    expect(normalizeRenderedSpacing(canonical)).toBe('2 000,00 ₴');
   });
 });

--- a/frontend/lib/tests/shop/order-items-snapshot-immutable.test.ts
+++ b/frontend/lib/tests/shop/order-items-snapshot-immutable.test.ts
@@ -22,7 +22,9 @@ import {
   products,
 } from '@/db/schema';
 import { resetEnvCache } from '@/lib/env';
+import { rehydrateCartItems } from '@/lib/services/products';
 import { deriveTestIpFromIdemKey } from '@/lib/tests/helpers/ip';
+import { TEST_LEGAL_CONSENT } from '@/lib/tests/shop/test-legal-consent';
 
 vi.mock('@/lib/auth', async () => {
   resetEnvCache();
@@ -181,7 +183,7 @@ describe('P0-6 snapshots: order_items immutability', () => {
       await db.insert(productPrices).values({
         id: priceId,
         productId,
-        currency: 'USD',
+        currency: 'UAH',
         priceMinor: 900,
         originalPriceMinor: null,
         price: '9.00',
@@ -189,12 +191,18 @@ describe('P0-6 snapshots: order_items immutability', () => {
       });
 
       const idem = randomUUID();
+      const quote = await rehydrateCartItems(
+        [{ productId, quantity: 1 }],
+        'UAH'
+      );
       const req = makeJsonRequest(
         'http://localhost:3000/api/shop/checkout',
         {
           items: [{ productId, quantity: 1 }],
+          legalConsent: TEST_LEGAL_CONSENT,
           paymentProvider: 'stripe',
           paymentMethod: 'stripe_card',
+          pricingFingerprint: quote.summary.pricingFingerprint,
         },
         {
           'Accept-Language': 'en-US,en;q=0.9',
@@ -264,7 +272,7 @@ describe('P0-6 snapshots: order_items immutability', () => {
         .where(
           and(
             eq(productPrices.productId, productId),
-            eq(productPrices.currency, 'USD')
+            eq(productPrices.currency, 'UAH')
           )
         );
 

--- a/frontend/lib/tests/shop/product-admin-create-pricing-policy.test.ts
+++ b/frontend/lib/tests/shop/product-admin-create-pricing-policy.test.ts
@@ -1,0 +1,120 @@
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { db } from '@/db';
+import { productPrices, products } from '@/db/schema';
+import { createProduct } from '@/lib/services/products';
+import { toDbMoney } from '@/lib/shop/money';
+import { assertNotProductionDb } from '@/lib/tests/helpers/db-safety';
+import { productAdminSchema } from '@/lib/validation/shop';
+
+vi.mock('@/lib/cloudinary', () => ({
+  uploadProductImageFromFile: vi.fn(async () => ({
+    secureUrl: 'https://example.com/admin-uah-only.png',
+    publicId: 'products/admin-uah-only',
+  })),
+  destroyProductImage: vi.fn(async () => {}),
+}));
+
+function uniqueSlug(prefix = 'admin-create-price-policy') {
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+describe.sequential('admin create pricing policy', () => {
+  const createdProductIds: string[] = [];
+
+  beforeAll(() => {
+    assertNotProductionDb();
+  });
+
+  afterEach(async () => {
+    for (const productId of createdProductIds.splice(0)) {
+      await db
+        .delete(productPrices)
+        .where(eq(productPrices.productId, productId))
+        .catch(() => undefined);
+      await db
+        .delete(products)
+        .where(eq(products.id, productId))
+        .catch(() => undefined);
+    }
+  });
+
+  it('accepts UAH-only pricing in the admin create schema', () => {
+    const result = productAdminSchema.safeParse({
+      title: 'UAH-only schema product',
+      slug: uniqueSlug('admin-schema-uah-only'),
+      prices: [{ currency: 'UAH', priceMinor: 5100, originalPriceMinor: null }],
+      badge: 'NONE',
+      colors: [],
+      sizes: [],
+      stock: 2,
+      isActive: true,
+      isFeatured: false,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('creates a product from UAH-only admin pricing while keeping the legacy USD mirror explicit', async () => {
+    const created = await createProduct({
+      title: 'UAH-only create product',
+      slug: uniqueSlug('admin-create-uah-only'),
+      description: null,
+      badge: 'NONE',
+      isActive: true,
+      isFeatured: false,
+      stock: 4,
+      prices: [{ currency: 'UAH', priceMinor: 5100, originalPriceMinor: null }],
+      image: new File([new Uint8Array([1, 2, 3, 4])], 'create-uah-only.png', {
+        type: 'image/png',
+      }),
+    } as any);
+
+    createdProductIds.push(created.id);
+
+    const [legacy] = await db
+      .select({
+        price: products.price,
+        originalPrice: products.originalPrice,
+        currency: products.currency,
+      })
+      .from(products)
+      .where(eq(products.id, created.id))
+      .limit(1);
+
+    const [uah] = await db
+      .select({
+        priceMinor: productPrices.priceMinor,
+        originalPriceMinor: productPrices.originalPriceMinor,
+      })
+      .from(productPrices)
+      .where(
+        and(
+          eq(productPrices.productId, created.id),
+          eq(productPrices.currency, 'UAH')
+        )
+      )
+      .limit(1);
+
+    const [usd] = await db
+      .select({
+        priceMinor: productPrices.priceMinor,
+      })
+      .from(productPrices)
+      .where(
+        and(
+          eq(productPrices.productId, created.id),
+          eq(productPrices.currency, 'USD')
+        )
+      )
+      .limit(1);
+
+    expect(legacy.currency).toBe('USD');
+    expect(String(legacy.price)).toBe(String(toDbMoney(5100)));
+    expect(legacy.originalPrice).toBeNull();
+    expect(uah?.priceMinor).toBe(5100);
+    expect(uah?.originalPriceMinor).toBeNull();
+    expect(usd).toBeUndefined();
+  });
+});

--- a/frontend/lib/tests/shop/product-admin-create-pricing-policy.test.ts
+++ b/frontend/lib/tests/shop/product-admin-create-pricing-policy.test.ts
@@ -136,8 +136,10 @@ describe.sequential('admin create pricing policy', () => {
   });
 
   it('rejects USD-only admin pricing at create-time even through the service layer', async () => {
-    await expect(
-      createProduct({
+    expect.assertions(3);
+
+    try {
+      await createProduct({
         title: 'USD-only create product',
         slug: uniqueSlug('admin-create-usd-only'),
         description: null,
@@ -151,10 +153,14 @@ describe.sequential('admin create pricing policy', () => {
         image: new File([new Uint8Array([1, 2, 3, 4])], 'create-usd-only.png', {
           type: 'image/png',
         }),
-      } as any)
-    ).rejects.toMatchObject({
-      code: 'PRICE_CONFIG_ERROR',
-      currency: 'UAH',
-    });
+      } as any);
+      throw new Error('Expected createProduct to throw PriceConfigError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(PriceConfigError);
+      expect((error as PriceConfigError).code).toBe('PRICE_CONFIG_ERROR');
+      expect((error as PriceConfigError & { currency?: string }).currency).toBe(
+        'UAH'
+      );
+    }
   });
 });

--- a/frontend/lib/tests/shop/product-admin-create-pricing-policy.test.ts
+++ b/frontend/lib/tests/shop/product-admin-create-pricing-policy.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { db } from '@/db';
 import { productPrices, products } from '@/db/schema';
+import { PriceConfigError } from '@/lib/services/errors';
 import { createProduct } from '@/lib/services/products';
 import { toDbMoney } from '@/lib/shop/money';
 import { assertNotProductionDb } from '@/lib/tests/helpers/db-safety';
@@ -54,6 +55,22 @@ describe.sequential('admin create pricing policy', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('rejects USD-only pricing in the admin create schema', () => {
+    const result = productAdminSchema.safeParse({
+      title: 'USD-only schema product',
+      slug: uniqueSlug('admin-schema-usd-only'),
+      prices: [{ currency: 'USD', priceMinor: 5100, originalPriceMinor: null }],
+      badge: 'NONE',
+      colors: [],
+      sizes: [],
+      stock: 2,
+      isActive: true,
+      isFeatured: false,
+    });
+
+    expect(result.success).toBe(false);
   });
 
   it('creates a product from UAH-only admin pricing while keeping the legacy USD mirror explicit', async () => {
@@ -116,5 +133,28 @@ describe.sequential('admin create pricing policy', () => {
     expect(uah?.priceMinor).toBe(5100);
     expect(uah?.originalPriceMinor).toBeNull();
     expect(usd).toBeUndefined();
+  });
+
+  it('rejects USD-only admin pricing at create-time even through the service layer', async () => {
+    await expect(
+      createProduct({
+        title: 'USD-only create product',
+        slug: uniqueSlug('admin-create-usd-only'),
+        description: null,
+        badge: 'NONE',
+        isActive: true,
+        isFeatured: false,
+        stock: 4,
+        prices: [
+          { currency: 'USD', priceMinor: 5100, originalPriceMinor: null },
+        ],
+        image: new File([new Uint8Array([1, 2, 3, 4])], 'create-usd-only.png', {
+          type: 'image/png',
+        }),
+      } as any)
+    ).rejects.toMatchObject({
+      code: 'PRICE_CONFIG_ERROR',
+      currency: 'UAH',
+    });
   });
 });

--- a/frontend/lib/tests/shop/product-admin-create-pricing-policy.test.ts
+++ b/frontend/lib/tests/shop/product-admin-create-pricing-policy.test.ts
@@ -32,12 +32,8 @@ describe.sequential('admin create pricing policy', () => {
     for (const productId of createdProductIds.splice(0)) {
       await db
         .delete(productPrices)
-        .where(eq(productPrices.productId, productId))
-        .catch(() => undefined);
-      await db
-        .delete(products)
-        .where(eq(products.id, productId))
-        .catch(() => undefined);
+        .where(eq(productPrices.productId, productId));
+      await db.delete(products).where(eq(products.id, productId));
     }
   });
 
@@ -127,6 +123,10 @@ describe.sequential('admin create pricing policy', () => {
       )
       .limit(1);
 
+    expect(
+      legacy,
+      'Expected legacy products row to exist after create'
+    ).toBeDefined();
     expect(legacy.currency).toBe('USD');
     expect(String(legacy.price)).toBe(String(toDbMoney(5100)));
     expect(legacy.originalPrice).toBeNull();

--- a/frontend/lib/tests/shop/product-admin-merged-prices-policy.test.ts
+++ b/frontend/lib/tests/shop/product-admin-merged-prices-policy.test.ts
@@ -4,13 +4,27 @@ import { PriceConfigError } from '@/lib/services/errors';
 import { assertMergedPricesPolicy } from '@/lib/services/products/prices';
 
 describe('assertMergedPricesPolicy (merged-state)', () => {
-  it('allows UAH-only merged state when USD compatibility is not required', () => {
+  it('allows UAH-only merged state when the standard storefront currency is present', () => {
     expect(() =>
       assertMergedPricesPolicy(
         [{ currency: 'UAH', priceMinor: 1000, originalPriceMinor: null }],
-        { productId: 'p1', requireUsd: false }
+        { productId: 'p1', requiredCurrency: 'UAH', requireUsd: false }
       )
     ).not.toThrow();
+  });
+
+  it('throws PRICE_CONFIG_ERROR when the standard storefront currency is missing from merged state', () => {
+    try {
+      assertMergedPricesPolicy(
+        [{ currency: 'USD', priceMinor: 1000, originalPriceMinor: null }],
+        { productId: 'p1', requiredCurrency: 'UAH', requireUsd: false }
+      );
+      throw new Error('Expected PriceConfigError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(PriceConfigError);
+      expect((e as any).code).toBe('PRICE_CONFIG_ERROR');
+      expect((e as any).currency).toBe('UAH');
+    }
   });
 
   it('still throws PRICE_CONFIG_ERROR when explicit USD compatibility is required', () => {

--- a/frontend/lib/tests/shop/product-admin-merged-prices-policy.test.ts
+++ b/frontend/lib/tests/shop/product-admin-merged-prices-policy.test.ts
@@ -4,7 +4,16 @@ import { PriceConfigError } from '@/lib/services/errors';
 import { assertMergedPricesPolicy } from '@/lib/services/products/prices';
 
 describe('assertMergedPricesPolicy (merged-state)', () => {
-  it('throws PRICE_CONFIG_ERROR when USD is missing after merge', () => {
+  it('allows UAH-only merged state when USD compatibility is not required', () => {
+    expect(() =>
+      assertMergedPricesPolicy(
+        [{ currency: 'UAH', priceMinor: 1000, originalPriceMinor: null }],
+        { productId: 'p1', requireUsd: false }
+      )
+    ).not.toThrow();
+  });
+
+  it('still throws PRICE_CONFIG_ERROR when explicit USD compatibility is required', () => {
     try {
       assertMergedPricesPolicy(
         [{ currency: 'UAH', priceMinor: 1000, originalPriceMinor: null }],
@@ -15,17 +24,5 @@ describe('assertMergedPricesPolicy (merged-state)', () => {
       expect(e).toBeInstanceOf(PriceConfigError);
       expect((e as any).code).toBe('PRICE_CONFIG_ERROR');
     }
-  });
-
-  it('passes when USD exists in merged state', () => {
-    expect(() =>
-      assertMergedPricesPolicy(
-        [
-          { currency: 'UAH', priceMinor: 1000, originalPriceMinor: null },
-          { currency: 'USD', priceMinor: 500, originalPriceMinor: null },
-        ],
-        { productId: 'p1', requireUsd: true }
-      )
-    ).not.toThrow();
   });
 });

--- a/frontend/lib/tests/shop/product-photo-plan-fixes.test.ts
+++ b/frontend/lib/tests/shop/product-photo-plan-fixes.test.ts
@@ -4,9 +4,52 @@ import userEvent from '@testing-library/user-event';
 import { createElement } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import en from '@/messages/en.json';
+
 vi.mock('next/image', () => ({
   default: () => null,
 }));
+
+function getAtPath(
+  root: Record<string, unknown>,
+  path: readonly string[]
+): unknown {
+  let current: unknown = root;
+
+  for (const segment of path) {
+    if (!current || typeof current !== 'object' || !(segment in current)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+}
+
+function formatMessage(
+  template: string,
+  values?: Record<string, string | number>
+) {
+  return template.replace(/\{(\w+)\}/g, (_match, key: string) =>
+    values && key in values ? String(values[key]) : `{${key}}`
+  );
+}
+
+function getFormMessage(key: string, values?: Record<string, string | number>) {
+  const raw = getAtPath(en as Record<string, unknown>, [
+    'shop',
+    'admin',
+    'products',
+    'form',
+    ...key.split('.'),
+  ]);
+
+  if (typeof raw !== 'string') {
+    throw new Error(`Missing test message: ${key}`);
+  }
+
+  return formatMessage(raw, values);
+}
 
 vi.mock('@/i18n/routing', () => ({
   useRouter: () => ({
@@ -15,11 +58,27 @@ vi.mock('@/i18n/routing', () => ({
   }),
 }));
 
+vi.mock('next-intl', () => ({
+  useTranslations:
+    (namespace: string) =>
+    (key: string, values?: Record<string, string | number>) => {
+      const raw = getAtPath(en as Record<string, unknown>, [
+        ...namespace.split('.'),
+        ...key.split('.'),
+      ]);
+
+      if (typeof raw !== 'string') {
+        throw new Error(`Missing test translation: ${namespace}.${key}`);
+      }
+
+      return formatMessage(raw, values);
+    },
+}));
+
 import {
   buildPhotoPlanSubmission,
   ensureUiPhotos,
   getPhotoPlanSubmissionError,
-  LEGACY_PHOTO_MIGRATION_REQUIRED_MESSAGE,
   ProductForm,
   revokeSupersededPhotoPreviewUrls,
 } from '@/app/[locale]/admin/shop/products/_components/ProductForm';
@@ -32,6 +91,10 @@ afterEach(() => {
 });
 
 describe('product photo plan fixes', () => {
+  const legacyPhotoMigrationRequiredMessage = getFormMessage(
+    'errors.legacyPhotoMigrationRequired'
+  );
+
   it('does not serialize fake existing image ids for legacy imageUrl-only edit state', () => {
     const photos = ensureUiPhotos({
       imageUrl: 'https://example.com/legacy-only.png',
@@ -46,7 +109,9 @@ describe('product photo plan fixes', () => {
       }),
     ]);
 
-    const submission = buildPhotoPlanSubmission(photos);
+    const submission = buildPhotoPlanSubmission(photos, {
+      legacyPhotoMigrationRequired: legacyPhotoMigrationRequiredMessage,
+    });
 
     expect(submission.photoPlan).toBeUndefined();
     expect(submission.newPhotos).toEqual([]);
@@ -67,11 +132,18 @@ describe('product photo plan fixes', () => {
       },
     ];
 
-    expect(getPhotoPlanSubmissionError(mixedPhotos)).toBe(
-      LEGACY_PHOTO_MIGRATION_REQUIRED_MESSAGE
-    );
-    expect(() => buildPhotoPlanSubmission(mixedPhotos)).toThrowError(
-      LEGACY_PHOTO_MIGRATION_REQUIRED_MESSAGE
+    expect(
+      getPhotoPlanSubmissionError(mixedPhotos, {
+        legacyPhotoMigrationRequired: legacyPhotoMigrationRequiredMessage,
+      })
+    ).toBe(legacyPhotoMigrationRequiredMessage);
+    expect(
+      () =>
+        buildPhotoPlanSubmission(mixedPhotos, {
+          legacyPhotoMigrationRequired: legacyPhotoMigrationRequiredMessage,
+        })
+    ).toThrowError(
+      legacyPhotoMigrationRequiredMessage
     );
   });
 
@@ -91,7 +163,7 @@ describe('product photo plan fixes', () => {
           slug: 'legacy-product',
           prices: [
             {
-              currency: 'USD',
+              currency: 'UAH',
               priceMinor: 5900,
               originalPriceMinor: null,
             },
@@ -107,17 +179,19 @@ describe('product photo plan fixes', () => {
       })
     );
 
-    const fileInput = screen.getByLabelText('Photos');
+    const fileInput = screen.getByLabelText(getFormMessage('fields.photos'));
     await user.upload(
       fileInput,
       new File(['new'], 'new.png', { type: 'image/png' })
     );
 
-    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+    await user.click(
+      screen.getByRole('button', { name: getFormMessage('actions.save') })
+    );
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(
-      await screen.findByText(LEGACY_PHOTO_MIGRATION_REQUIRED_MESSAGE)
+      await screen.findByText(legacyPhotoMigrationRequiredMessage)
     ).toBeInTheDocument();
   });
 

--- a/frontend/lib/tests/shop/product-prices-write-authority-phase8.test.ts
+++ b/frontend/lib/tests/shop/product-prices-write-authority-phase8.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { db } from '@/db';
 import { productPrices, products } from '@/db/schema';
-import { PriceConfigError } from '@/lib/services/errors';
 import { createProduct } from '@/lib/services/products';
 import { updateProduct } from '@/lib/services/products';
 import { toDbMoney } from '@/lib/shop/money';
@@ -260,6 +259,51 @@ describe.sequential('product_prices write authority (phase 8)', () => {
     });
   });
 
+  it('rejects a non-price update that would preserve a USD-only product state', async () => {
+    const [product] = await db
+      .insert(products)
+      .values({
+        slug: uniqueSlug(),
+        title: 'Phase8 USD-only non-price update',
+        description: null,
+        imageUrl: 'https://example.com/p8-usd-only-non-price.png',
+        imagePublicId: null,
+        price: toDbMoney(1200),
+        originalPrice: null,
+        currency: 'USD',
+        category: null,
+        type: null,
+        colors: [],
+        sizes: [],
+        badge: 'NONE',
+        isActive: true,
+        isFeatured: false,
+        stock: 10,
+        sku: null,
+      })
+      .returning();
+
+    createdProductIds.push(product.id);
+
+    await db.insert(productPrices).values({
+      productId: product.id,
+      currency: 'USD',
+      priceMinor: 1200,
+      originalPriceMinor: null,
+      price: toDbMoney(1200),
+      originalPrice: null,
+    });
+
+    await expect(
+      updateProduct(product.id, {
+        title: 'Renamed without touching prices',
+      } as any)
+    ).rejects.toMatchObject({
+      code: 'PRICE_CONFIG_ERROR',
+      currency: 'UAH',
+    });
+  });
+
   it('updates a UAH-only product row without requiring a dormant USD price row', async () => {
     const created = await createProduct({
       title: 'Phase8 UAH-only update',
@@ -320,5 +364,72 @@ describe.sequential('product_prices write authority (phase 8)', () => {
     expect(String(legacy.price)).toBe(String(toDbMoney(4100)));
     expect(usd).toBeUndefined();
     expect(uah?.priceMinor).toBe(4300);
+  });
+
+  it('allows a non-price update when the product already has a UAH storefront row', async () => {
+    const [product] = await db
+      .insert(products)
+      .values({
+        slug: uniqueSlug(),
+        title: 'Phase8 UAH-present non-price update',
+        description: null,
+        imageUrl: 'https://example.com/p8-uah-present-non-price.png',
+        imagePublicId: null,
+        price: toDbMoney(1200),
+        originalPrice: null,
+        currency: 'USD',
+        category: null,
+        type: null,
+        colors: [],
+        sizes: [],
+        badge: 'NONE',
+        isActive: true,
+        isFeatured: false,
+        stock: 10,
+        sku: null,
+      })
+      .returning();
+
+    createdProductIds.push(product.id);
+
+    await db.insert(productPrices).values([
+      {
+        productId: product.id,
+        currency: 'USD',
+        priceMinor: 1200,
+        originalPriceMinor: null,
+        price: toDbMoney(1200),
+        originalPrice: null,
+      },
+      {
+        productId: product.id,
+        currency: 'UAH',
+        priceMinor: 4700,
+        originalPriceMinor: null,
+        price: toDbMoney(4700),
+        originalPrice: null,
+      },
+    ]);
+
+    const updated = await updateProduct(product.id, {
+      title: 'Renamed with UAH-present pricing',
+    } as any);
+
+    expect(updated.title).toBe('Renamed with UAH-present pricing');
+
+    const [uah] = await db
+      .select({
+        priceMinor: productPrices.priceMinor,
+      })
+      .from(productPrices)
+      .where(
+        and(
+          eq(productPrices.productId, product.id),
+          eq(productPrices.currency, 'UAH')
+        )
+      )
+      .limit(1);
+
+    expect(uah?.priceMinor).toBe(4700);
   });
 });

--- a/frontend/lib/tests/shop/product-prices-write-authority-phase8.test.ts
+++ b/frontend/lib/tests/shop/product-prices-write-authority-phase8.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { db } from '@/db';
 import { productPrices, products } from '@/db/schema';
+import { PriceConfigError } from '@/lib/services/errors';
 import { createProduct } from '@/lib/services/products';
 import { updateProduct } from '@/lib/services/products';
 import { toDbMoney } from '@/lib/shop/money';
@@ -66,14 +67,24 @@ describe.sequential('product_prices write authority (phase 8)', () => {
 
     createdProductIds.push(product.id);
 
-    await db.insert(productPrices).values({
-      productId: product.id,
-      currency: 'USD',
-      priceMinor: 1000,
-      originalPriceMinor: null,
-      price: toDbMoney(1000),
-      originalPrice: null,
-    });
+    await db.insert(productPrices).values([
+      {
+        productId: product.id,
+        currency: 'USD',
+        priceMinor: 1000,
+        originalPriceMinor: null,
+        price: toDbMoney(1000),
+        originalPrice: null,
+      },
+      {
+        productId: product.id,
+        currency: 'UAH',
+        priceMinor: 4100,
+        originalPriceMinor: null,
+        price: toDbMoney(4100),
+        originalPrice: null,
+      },
+    ]);
 
     await updateProduct(product.id, {
       prices: [{ currency: 'USD', priceMinor: 2500, originalPriceMinor: null }],
@@ -102,10 +113,24 @@ describe.sequential('product_prices write authority (phase 8)', () => {
       )
       .limit(1);
 
+    const [uah] = await db
+      .select({
+        priceMinor: productPrices.priceMinor,
+      })
+      .from(productPrices)
+      .where(
+        and(
+          eq(productPrices.productId, product.id),
+          eq(productPrices.currency, 'UAH')
+        )
+      )
+      .limit(1);
+
     expect(String(legacy.price)).toBe(String(toDbMoney(1000)));
     expect(legacy.originalPrice).toBeNull();
     expect(usd.priceMinor).toBe(2500);
     expect(usd.originalPriceMinor).toBeNull();
+    expect(uah?.priceMinor).toBe(4100);
   });
 
   it('upserts non-USD row in product_prices without mutating legacy products.price fields', async () => {
@@ -186,6 +211,53 @@ describe.sequential('product_prices write authority (phase 8)', () => {
     expect(legacy.originalPrice).toBeNull();
     expect(usd.priceMinor).toBe(1200);
     expect(uah.priceMinor).toBe(4700);
+  });
+
+  it('rejects a pricing update that would leave the product without a UAH storefront row', async () => {
+    const [product] = await db
+      .insert(products)
+      .values({
+        slug: uniqueSlug(),
+        title: 'Phase8 USD-only merged state',
+        description: null,
+        imageUrl: 'https://example.com/p8-usd-only.png',
+        imagePublicId: null,
+        price: toDbMoney(1200),
+        originalPrice: null,
+        currency: 'USD',
+        category: null,
+        type: null,
+        colors: [],
+        sizes: [],
+        badge: 'NONE',
+        isActive: true,
+        isFeatured: false,
+        stock: 10,
+        sku: null,
+      })
+      .returning();
+
+    createdProductIds.push(product.id);
+
+    await db.insert(productPrices).values({
+      productId: product.id,
+      currency: 'USD',
+      priceMinor: 1200,
+      originalPriceMinor: null,
+      price: toDbMoney(1200),
+      originalPrice: null,
+    });
+
+    await expect(
+      updateProduct(product.id, {
+        prices: [
+          { currency: 'USD', priceMinor: 1500, originalPriceMinor: null },
+        ],
+      } as any)
+    ).rejects.toMatchObject({
+      code: 'PRICE_CONFIG_ERROR',
+      currency: 'UAH',
+    });
   });
 
   it('updates a UAH-only product row without requiring a dormant USD price row', async () => {

--- a/frontend/lib/tests/shop/product-prices-write-authority-phase8.test.ts
+++ b/frontend/lib/tests/shop/product-prices-write-authority-phase8.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { db } from '@/db';
 import { productPrices, products } from '@/db/schema';
+import { createProduct } from '@/lib/services/products';
 import { updateProduct } from '@/lib/services/products';
 import { toDbMoney } from '@/lib/shop/money';
 import { assertNotProductionDb } from '@/lib/tests/helpers/db-safety';
@@ -185,5 +186,67 @@ describe.sequential('product_prices write authority (phase 8)', () => {
     expect(legacy.originalPrice).toBeNull();
     expect(usd.priceMinor).toBe(1200);
     expect(uah.priceMinor).toBe(4700);
+  });
+
+  it('updates a UAH-only product row without requiring a dormant USD price row', async () => {
+    const created = await createProduct({
+      title: 'Phase8 UAH-only update',
+      slug: uniqueSlug(),
+      description: null,
+      badge: 'NONE',
+      isActive: true,
+      isFeatured: false,
+      stock: 10,
+      prices: [{ currency: 'UAH', priceMinor: 4100, originalPriceMinor: null }],
+      image: new File([new Uint8Array([1, 2, 3])], 'p8-uah-only.png', {
+        type: 'image/png',
+      }),
+    } as any);
+
+    createdProductIds.push(created.id);
+
+    await updateProduct(created.id, {
+      prices: [{ currency: 'UAH', priceMinor: 4300, originalPriceMinor: null }],
+    } as any);
+
+    const [legacy] = await db
+      .select({
+        price: products.price,
+        currency: products.currency,
+      })
+      .from(products)
+      .where(eq(products.id, created.id))
+      .limit(1);
+
+    const [usd] = await db
+      .select({
+        priceMinor: productPrices.priceMinor,
+      })
+      .from(productPrices)
+      .where(
+        and(
+          eq(productPrices.productId, created.id),
+          eq(productPrices.currency, 'USD')
+        )
+      )
+      .limit(1);
+
+    const [uah] = await db
+      .select({
+        priceMinor: productPrices.priceMinor,
+      })
+      .from(productPrices)
+      .where(
+        and(
+          eq(productPrices.productId, created.id),
+          eq(productPrices.currency, 'UAH')
+        )
+      )
+      .limit(1);
+
+    expect(legacy.currency).toBe('USD');
+    expect(String(legacy.price)).toBe(String(toDbMoney(4100)));
+    expect(usd).toBeUndefined();
+    expect(uah?.priceMinor).toBe(4300);
   });
 });

--- a/frontend/lib/tests/shop/public-cart-env-contract.test.ts
+++ b/frontend/lib/tests/shop/public-cart-env-contract.test.ts
@@ -47,6 +47,24 @@ describe('public cart env contract', () => {
     expect(isMonobankEnabledMock).not.toHaveBeenCalled();
   });
 
+  it('treats normalized truthy env values as enabled for capability resolution', async () => {
+    readServerEnvMock.mockImplementation((key: string) => {
+      if (key === 'PAYMENTS_ENABLED') return ' YES ';
+      if (key === 'SHOP_MONOBANK_GPAY_ENABLED') return ' On ';
+      return undefined;
+    });
+    isMonobankEnabledMock.mockReturnValue(true);
+
+    const mod = await import('@/app/[locale]/shop/cart/capabilities');
+
+    expect(mod.resolveMonobankCheckoutEnabled()).toBe(true);
+    expect(mod.resolveMonobankGooglePayEnabled()).toBe(true);
+    expect(readServerEnvMock).toHaveBeenCalledWith('PAYMENTS_ENABLED');
+    expect(readServerEnvMock).toHaveBeenCalledWith(
+      'SHOP_MONOBANK_GPAY_ENABLED'
+    );
+  });
+
   it('resolves monobank google pay from readServerEnv SHOP_MONOBANK_GPAY_ENABLED', async () => {
     readServerEnvMock.mockImplementation((key: string) => {
       if (key === 'PAYMENTS_ENABLED') return 'true';

--- a/frontend/lib/tests/shop/public-product-visibility.test.ts
+++ b/frontend/lib/tests/shop/public-product-visibility.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { db } from '@/db';
 import { getPublicProductBySlug } from '@/db/queries/shop/products';
 import { productPrices, products } from '@/db/schema';
+import { getProductPageData } from '@/lib/shop/data';
 
 function logTestCleanupFailed(meta: Record<string, unknown>, error: unknown) {
   console.error('[test cleanup failed]', {
@@ -119,6 +120,58 @@ describe('P0-5 Public products: inactive not visible', () => {
       expect(result).not.toBeNull();
       expect(result!.slug).toBe(slug);
       expect(result!.currency).toBe('USD');
+    } finally {
+      await cleanup(productId);
+    }
+  });
+
+  it('keeps PDP product visibility on non-uk locales when only the UAH price row exists', async () => {
+    const productId = randomUUID();
+    const slug = `uah-only-${randomUUID()}`;
+
+    try {
+      await db.insert(products).values({
+        id: productId,
+        slug,
+        title: 'UAH-only product',
+        description: null,
+        imageUrl: 'https://placehold.co/600x600',
+        imagePublicId: null,
+        category: null,
+        type: null,
+        colors: [],
+        sizes: [],
+        badge: 'NONE',
+        isActive: true,
+        isFeatured: false,
+        stock: 5,
+        sku: null,
+
+        price: '10.00',
+        originalPrice: null,
+        currency: 'USD',
+      });
+
+      await db.insert(productPrices).values({
+        id: randomUUID(),
+        productId,
+        currency: 'UAH',
+        priceMinor: 4400,
+        originalPriceMinor: null,
+        price: '44.00',
+        originalPrice: null,
+      });
+
+      const result = await getProductPageData(slug, 'en');
+
+      expect(result.kind).toBe('available');
+      if (result.kind !== 'available') {
+        throw new Error('Expected PDP data to stay available for UAH-only row');
+      }
+
+      expect(result.commerceProduct.slug).toBe(slug);
+      expect(result.commerceProduct.currency).toBe('UAH');
+      expect(result.commerceProduct.price).toBe(4400);
     } finally {
       await cleanup(productId);
     }

--- a/frontend/lib/tests/shop/public-storefront-read-policy.test.ts
+++ b/frontend/lib/tests/shop/public-storefront-read-policy.test.ts
@@ -58,36 +58,45 @@ describe('public storefront read policy', () => {
       );
     }
 
-    expect(shopQueryMocks.getActiveProductsPage).toHaveBeenNthCalledWith(1, {
-      currency: 'UAH',
-      limit: 24,
-      offset: 0,
-      category: undefined,
-      type: undefined,
-      color: undefined,
-      size: undefined,
-      sort: 'newest',
-    });
-    expect(shopQueryMocks.getActiveProductsPage).toHaveBeenNthCalledWith(2, {
-      currency: 'UAH',
-      limit: 24,
-      offset: 0,
-      category: undefined,
-      type: undefined,
-      color: undefined,
-      size: undefined,
-      sort: 'newest',
-    });
-    expect(shopQueryMocks.getActiveProductsPage).toHaveBeenNthCalledWith(3, {
-      currency: 'UAH',
-      limit: 24,
-      offset: 0,
-      category: undefined,
-      type: undefined,
-      color: undefined,
-      size: undefined,
-      sort: 'newest',
-    });
+    expect(shopQueryMocks.getActiveProductsPage).toHaveBeenCalledTimes(3);
+    expect(shopQueryMocks.getActiveProductsPage.mock.calls).toEqual([
+      [
+        {
+          currency: 'UAH',
+          limit: 24,
+          offset: 0,
+          category: undefined,
+          type: undefined,
+          color: undefined,
+          size: undefined,
+          sort: 'newest',
+        },
+      ],
+      [
+        {
+          currency: 'UAH',
+          limit: 24,
+          offset: 0,
+          category: undefined,
+          type: undefined,
+          color: undefined,
+          size: undefined,
+          sort: 'newest',
+        },
+      ],
+      [
+        {
+          currency: 'UAH',
+          limit: 24,
+          offset: 0,
+          category: undefined,
+          type: undefined,
+          color: undefined,
+          size: undefined,
+          sort: 'newest',
+        },
+      ],
+    ]);
   });
 
   it('uses the standard storefront UAH currency for PDP reads on non-uk locales', async () => {
@@ -97,10 +106,10 @@ describe('public storefront read policy', () => {
 
     const result = await getProductPageData('policy-product', 'en');
 
-    expect(shopQueryMocks.getPublicProductBySlug).toHaveBeenCalledWith(
-      'policy-product',
-      'UAH'
-    );
+    expect(shopQueryMocks.getPublicProductBySlug).toHaveBeenCalledTimes(1);
+    expect(shopQueryMocks.getPublicProductBySlug.mock.calls).toEqual([
+      ['policy-product', 'UAH'],
+    ]);
     expect(result.kind).toBe('available');
   });
 });

--- a/frontend/lib/tests/shop/public-storefront-read-policy.test.ts
+++ b/frontend/lib/tests/shop/public-storefront-read-policy.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const shopQueryMocks = vi.hoisted(() => ({
+  getPublicProductBySlug: vi.fn(),
+  getPublicProductBaseBySlug: vi.fn(),
+  getActiveProductsPage: vi.fn(),
+}));
+
+vi.mock('@/db/queries/shop/products', () => shopQueryMocks);
+
+import { getCatalogProducts, getProductPageData } from '@/lib/shop/data';
+
+function makeDbProduct(overrides?: Record<string, unknown>) {
+  const createdAt = new Date('2026-03-01T00:00:00.000Z');
+
+  return {
+    id: 'product-1',
+    slug: 'product-1',
+    title: 'Product 1',
+    description: null,
+    imageUrl: '/placeholder.svg',
+    imagePublicId: null,
+    price: '44.00',
+    originalPrice: null,
+    currency: 'UAH' as const,
+    isActive: true,
+    isFeatured: false,
+    stock: 5,
+    sku: null,
+    category: 'apparel' as const,
+    type: 'shirts' as const,
+    colors: ['black'] as const,
+    sizes: ['M'] as const,
+    badge: 'NONE' as const,
+    images: [],
+    primaryImage: undefined,
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides,
+  };
+}
+
+describe('public storefront read policy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the standard storefront UAH currency for catalog reads on every locale', async () => {
+    shopQueryMocks.getActiveProductsPage.mockResolvedValue({
+      items: [makeDbProduct()],
+      total: 1,
+    });
+
+    for (const locale of ['uk', 'en', 'pl']) {
+      await getCatalogProducts(
+        { category: 'all', sort: 'newest', page: 1, limit: 24 },
+        locale
+      );
+    }
+
+    expect(shopQueryMocks.getActiveProductsPage).toHaveBeenNthCalledWith(1, {
+      currency: 'UAH',
+      limit: 24,
+      offset: 0,
+      category: undefined,
+      type: undefined,
+      color: undefined,
+      size: undefined,
+      sort: 'newest',
+    });
+    expect(shopQueryMocks.getActiveProductsPage).toHaveBeenNthCalledWith(2, {
+      currency: 'UAH',
+      limit: 24,
+      offset: 0,
+      category: undefined,
+      type: undefined,
+      color: undefined,
+      size: undefined,
+      sort: 'newest',
+    });
+    expect(shopQueryMocks.getActiveProductsPage).toHaveBeenNthCalledWith(3, {
+      currency: 'UAH',
+      limit: 24,
+      offset: 0,
+      category: undefined,
+      type: undefined,
+      color: undefined,
+      size: undefined,
+      sort: 'newest',
+    });
+  });
+
+  it('uses the standard storefront UAH currency for PDP reads on non-uk locales', async () => {
+    shopQueryMocks.getPublicProductBySlug.mockResolvedValueOnce(
+      makeDbProduct({ slug: 'policy-product' })
+    );
+
+    const result = await getProductPageData('policy-product', 'en');
+
+    expect(shopQueryMocks.getPublicProductBySlug).toHaveBeenCalledWith(
+      'policy-product',
+      'UAH'
+    );
+    expect(result.kind).toBe('available');
+  });
+});

--- a/frontend/lib/tests/shop/shipping-methods-route-p2.test.ts
+++ b/frontend/lib/tests/shop/shipping-methods-route-p2.test.ts
@@ -132,6 +132,30 @@ describe('shop shipping methods route (phase 2)', () => {
     }
   });
 
+  it('uses the standard storefront UA + UAH policy for en locale requests when query policy fields are omitted', async () => {
+    vi.stubEnv('SHOP_SHIPPING_ENABLED', 'true');
+    vi.stubEnv('SHOP_SHIPPING_NP_ENABLED', 'true');
+    vi.stubEnv('SHOP_SHIPPING_NP_WAREHOUSE_AMOUNT_MINOR', '500');
+    vi.stubEnv('SHOP_SHIPPING_NP_LOCKER_AMOUNT_MINOR', '400');
+    vi.stubEnv('SHOP_SHIPPING_NP_COURIER_AMOUNT_MINOR', '700');
+
+    const req = new NextRequest(
+      'http://localhost/api/shop/shipping/methods?locale=en'
+    );
+    const res = await GET(req);
+    const json: any = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({
+      success: true,
+      available: true,
+      reasonCode: 'OK',
+      country: 'UA',
+      currency: 'UAH',
+    });
+    expect(json.methods).toHaveLength(3);
+  });
+
   it('fails closed with NP_MISCONFIG in production-like runtime when NP config is placeholder', async () => {
     vi.stubEnv('APP_ENV', 'production');
     vi.stubEnv('SHOP_SHIPPING_ENABLED', 'true');

--- a/frontend/lib/tests/shop/shipping-np-cities-route-p2.test.ts
+++ b/frontend/lib/tests/shop/shipping-np-cities-route-p2.test.ts
@@ -132,6 +132,38 @@ describe('shop shipping np cities route (phase 2)', () => {
     }
   });
 
+  it('allows standard storefront city lookup on en locale without explicit currency or country params', async () => {
+    const cityRef = crypto.randomUUID();
+    await db.insert(npCities).values({
+      ref: cityRef,
+      nameUa: 'Kyiv Policy Local',
+      nameRu: null,
+      area: 'Kyivska',
+      region: 'Kyiv',
+      settlementType: 'City',
+      isActive: true,
+    });
+
+    try {
+      const req = new NextRequest(
+        'http://localhost/api/shop/shipping/np/cities?q=kyiv&locale=en'
+      );
+      const res = await GET(req);
+      const json: any = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json).toMatchObject({
+        success: true,
+        available: true,
+        reasonCode: 'OK',
+      });
+      expect(json.items.some((it: any) => it.ref === cityRef)).toBe(true);
+      expect(searchSettlementsMock).toHaveBeenCalledTimes(0);
+    } finally {
+      await db.delete(npCities).where(eq(npCities.ref, cityRef));
+    }
+  });
+
   it('NP down returns 200 + available=false NP_UNAVAILABLE with empty items', async () => {
     searchSettlementsMock.mockRejectedValue(
       new NovaPoshtaApiError('NP_HTTP_ERROR', 'temporary', 503)

--- a/frontend/lib/tests/shop/shipping-np-warehouses-route-p2.test.ts
+++ b/frontend/lib/tests/shop/shipping-np-warehouses-route-p2.test.ts
@@ -129,6 +129,53 @@ describe('shop shipping np warehouses route (phase 2)', () => {
     }
   });
 
+  it('allows standard storefront warehouse lookup on en locale without explicit currency or country params', async () => {
+    const cityRef = crypto.randomUUID();
+    const warehouseRef = crypto.randomUUID();
+
+    await db.insert(npCities).values({
+      ref: cityRef,
+      nameUa: 'Kyiv Policy Local',
+      nameRu: null,
+      area: 'Kyivska',
+      region: 'Kyiv',
+      settlementType: 'City',
+      isActive: true,
+    });
+
+    await db.insert(npWarehouses).values({
+      ref: warehouseRef,
+      settlementRef: cityRef,
+      cityRef,
+      number: '15',
+      type: 'Warehouse',
+      name: 'Policy Warehouse 15',
+      address: 'Kyiv, Policy 15',
+      isPostMachine: false,
+      isActive: true,
+    });
+
+    try {
+      const req = new NextRequest(
+        `http://localhost/api/shop/shipping/np/warehouses?cityRef=${cityRef}&q=policy&locale=en`
+      );
+      const res = await GET(req);
+      const json: any = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json).toMatchObject({
+        success: true,
+        available: true,
+        reasonCode: 'OK',
+      });
+      expect(json.items.some((it: any) => it.ref === warehouseRef)).toBe(true);
+      expect(getWarehousesByCityRefMock).toHaveBeenCalledTimes(0);
+    } finally {
+      await db.delete(npWarehouses).where(eq(npWarehouses.ref, warehouseRef));
+      await db.delete(npCities).where(eq(npCities.ref, cityRef));
+    }
+  });
+
   it('NP down returns 200 + available=false NP_UNAVAILABLE with empty items', async () => {
     const cityRef = crypto.randomUUID();
     getWarehousesByCityRefMock.mockRejectedValue(

--- a/frontend/lib/validation/shop.ts
+++ b/frontend/lib/validation/shop.ts
@@ -363,15 +363,6 @@ export const productAdminSchema = z
   .superRefine((data, ctx) => {
     refineNoDuplicateCurrencies(data.prices, ctx);
 
-    const usd = data.prices.find(p => p.currency === 'USD');
-    if (!usd) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['prices'],
-        message: 'USD price is required',
-      });
-    }
-
     if (data.badge === 'SALE') {
       data.prices.forEach((p, idx) => {
         if (p.originalPriceMinor == null) {

--- a/frontend/lib/validation/shop.ts
+++ b/frontend/lib/validation/shop.ts
@@ -338,6 +338,23 @@ function refineNoDuplicateCurrencies(
   });
 }
 
+function refineRequiresStandardStorefrontCurrency(
+  prices: AdminPriceRow[],
+  ctx: z.RefinementCtx
+) {
+  const hasUah = prices.some(
+    price => price.currency === 'UAH' && price.priceMinor >= 1
+  );
+
+  if (!hasUah) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['prices'],
+      message: 'UAH price is required for the standard storefront',
+    });
+  }
+}
+
 export const productAdminSchema = z
   .object({
     title: z.string().min(1),
@@ -362,6 +379,7 @@ export const productAdminSchema = z
   })
   .superRefine((data, ctx) => {
     refineNoDuplicateCurrencies(data.prices, ctx);
+    refineRequiresStandardStorefrontCurrency(data.prices, ctx);
 
     if (data.badge === 'SALE') {
       data.prices.forEach((p, idx) => {
@@ -553,10 +571,6 @@ export const checkoutPayloadSchema = z
       return;
     }
 
-    const paymentCurrency =
-      value.paymentCurrency ??
-      (value.paymentProvider === 'monobank' ? 'UAH' : 'USD');
-
     const provider = value.paymentProvider;
     const method = value.paymentMethod;
 
@@ -577,7 +591,8 @@ export const checkoutPayloadSchema = z
 
     if (
       (method === 'monobank_invoice' || method === 'monobank_google_pay') &&
-      paymentCurrency !== 'UAH'
+      value.paymentCurrency != null &&
+      value.paymentCurrency !== 'UAH'
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -574,6 +574,96 @@
           "active": "Active",
           "hidden": "Hidden",
           "featured": "Featured"
+        },
+        "form": {
+          "headings": {
+            "create": "Create new product",
+            "edit": "Edit product"
+          },
+          "sections": {
+            "basicInfo": "Basic info",
+            "inventorySku": "Inventory and SKU",
+            "catalogAttributes": "Catalog attributes",
+            "variants": "Variants",
+            "flagsBadge": "Flags and badge",
+            "description": "Description",
+            "photoManagement": "Photo management"
+          },
+          "fields": {
+            "title": "Title",
+            "slug": "Slug",
+            "slugHelp": "Auto-generated from title",
+            "price": "Price ({currency})",
+            "originalPrice": "Original price ({currency})",
+            "stock": "Stock",
+            "sku": "SKU",
+            "category": "Category",
+            "selectCategory": "Select category",
+            "type": "Type",
+            "selectType": "Select type",
+            "colors": "Colors",
+            "sizes": "Sizes",
+            "badge": "Badge",
+            "isActive": "Is Active",
+            "isFeatured": "Is Featured",
+            "description": "Description",
+            "photos": "Photos"
+          },
+          "badge": {
+            "none": "None",
+            "sale": "SALE",
+            "new": "NEW"
+          },
+          "pricing": {
+            "legend": "Prices",
+            "helper": "UAH is required for the standard storefront. USD is optional and kept only as a compatibility price.",
+            "uahLegend": "UAH (standard storefront)",
+            "usdLegend": "USD (compatibility optional)",
+            "policyPrefix": "Standard storefront checkout uses UAH. Save a UAH row in",
+            "policySuffix": "for the standard storefront currency. USD is optional compatibility only."
+          },
+          "photos": {
+            "helper": "Add one or more photos, reorder them, and mark exactly one as primary.",
+            "photoAlt": "Product photo {index}",
+            "photoLabel": "Photo {index}",
+            "primary": "Primary",
+            "status": {
+              "saved": "Saved",
+              "legacy": "Legacy image",
+              "new": "New upload"
+            },
+            "actions": {
+              "setPrimary": "Set primary",
+              "moveUp": "Move up",
+              "moveDown": "Move down",
+              "remove": "Remove"
+            }
+          },
+          "actions": {
+            "creating": "Creating...",
+            "updating": "Updating...",
+            "create": "Create product",
+            "save": "Save changes"
+          },
+          "errors": {
+            "legacyPhotoMigrationRequired": "Legacy product photos must be migrated before adding or reordering gallery photos.",
+            "photoRequired": "At least one product photo is required.",
+            "atLeastOnePrice": "At least one price is required.",
+            "uahRequired": "UAH price is required for the standard storefront.",
+            "priceRequiredWhenOriginalSet": "{currency}: price is required when original price is set.",
+            "invalidMoneyValue": "Invalid money value: \"{value}\"",
+            "invalidPriceValue": "Invalid price value.",
+            "securityMissing": "Security token missing. Refresh the page and retry.",
+            "slugConflict": "This slug is already used. Try changing the title.",
+            "photoUpdateFailed": "Failed to update product photos",
+            "saleOriginalRequired": "Original price is required for SALE.",
+            "saleOriginalGreater": "Original price must be greater than price for SALE.",
+            "securityExpired": "Security token expired. Refresh the page and retry.",
+            "createFailed": "Failed to create product",
+            "updateFailed": "Failed to update product",
+            "unexpectedCreate": "Unexpected error while creating product.",
+            "unexpectedUpdate": "Unexpected error while updating product."
+          }
         }
       },
       "statusToggle": {
@@ -780,6 +870,40 @@
           "previousFailed": "The previous payment attempt failed. Please try again",
           "completePayment": "Complete payment to finish your order"
         }
+      },
+      "paymentClient": {
+        "aria": {
+          "form": "Stripe payment form",
+          "paymentsDisabled": "Payments disabled",
+          "paymentInitializationFailed": "Payment initialization failed",
+          "nextSteps": "Next steps",
+          "securePayment": "Secure payment"
+        },
+        "summary": {
+          "payLabel": "Pay"
+        },
+        "messages": {
+          "notReady": "Payment is not ready yet. Please try again in a moment.",
+          "confirmFailed": "Unable to confirm payment.",
+          "unexpectedConfirmFailed": "We couldn't confirm your payment. Please try again.",
+          "paymentsDisabled": "Payments are disabled in this environment.",
+          "initializationFailed": "Payment cannot be initialized. Please try again later.",
+          "preparing": "Preparing secure payment..."
+        },
+        "actions": {
+          "processing": "Processing...",
+          "submit": "Submit payment",
+          "continue": "Continue",
+          "backToCart": "Back to cart",
+          "returnToCart": "Return to cart"
+        }
+      },
+      "errorPage": {
+        "metaTitle": "Checkout Error | DevLovers",
+        "metaDescription": "We couldn't complete the checkout. Try again or contact support.",
+        "checkoutNavigation": "Checkout navigation",
+        "orderDetails": "Order details",
+        "nextSteps": "Next steps"
       },
       "monobankGooglePay": {
         "supportedDevices": "Google Pay available on supported devices",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -574,6 +574,96 @@
           "active": "Aktywny",
           "hidden": "Ukryty",
           "featured": "Polecany"
+        },
+        "form": {
+          "headings": {
+            "create": "Utwórz nowy produkt",
+            "edit": "Edytuj produkt"
+          },
+          "sections": {
+            "basicInfo": "Podstawowe informacje",
+            "inventorySku": "Stan i SKU",
+            "catalogAttributes": "Atrybuty katalogu",
+            "variants": "Warianty",
+            "flagsBadge": "Flagi i odznaka",
+            "description": "Opis",
+            "photoManagement": "Zarządzanie zdjęciami"
+          },
+          "fields": {
+            "title": "Tytuł",
+            "slug": "Slug",
+            "slugHelp": "Generowany automatycznie z tytułu",
+            "price": "Cena ({currency})",
+            "originalPrice": "Cena pierwotna ({currency})",
+            "stock": "Stan",
+            "sku": "SKU",
+            "category": "Kategoria",
+            "selectCategory": "Wybierz kategorię",
+            "type": "Typ",
+            "selectType": "Wybierz typ",
+            "colors": "Kolory",
+            "sizes": "Rozmiary",
+            "badge": "Odznaka",
+            "isActive": "Aktywny",
+            "isFeatured": "Polecany",
+            "description": "Opis",
+            "photos": "Zdjęcia"
+          },
+          "badge": {
+            "none": "Brak",
+            "sale": "SALE",
+            "new": "NEW"
+          },
+          "pricing": {
+            "legend": "Ceny",
+            "helper": "UAH jest wymagana dla standardowego storefrontu. USD jest opcjonalna i pozostaje tylko dla zgodności.",
+            "uahLegend": "UAH (standardowy storefront)",
+            "usdLegend": "USD (opcjonalna zgodność)",
+            "policyPrefix": "Standardowy storefront finalizuje checkout w UAH. Zapisz wiersz UAH w",
+            "policySuffix": "dla waluty standardowego storefrontu. USD pozostaje tylko dla zgodności."
+          },
+          "photos": {
+            "helper": "Dodaj jedno lub więcej zdjęć, zmień ich kolejność i oznacz dokładnie jedno jako główne.",
+            "photoAlt": "Zdjęcie produktu {index}",
+            "photoLabel": "Zdjęcie {index}",
+            "primary": "Główne",
+            "status": {
+              "saved": "Zapisane",
+              "legacy": "Starszy obraz",
+              "new": "Nowy upload"
+            },
+            "actions": {
+              "setPrimary": "Ustaw jako główne",
+              "moveUp": "Przesuń w górę",
+              "moveDown": "Przesuń w dół",
+              "remove": "Usuń"
+            }
+          },
+          "actions": {
+            "creating": "Tworzenie...",
+            "updating": "Aktualizowanie...",
+            "create": "Utwórz produkt",
+            "save": "Zapisz zmiany"
+          },
+          "errors": {
+            "legacyPhotoMigrationRequired": "Starsze zdjęcia produktu trzeba zmigrować przed dodaniem lub zmianą kolejności zdjęć w galerii.",
+            "photoRequired": "Wymagane jest co najmniej jedno zdjęcie produktu.",
+            "atLeastOnePrice": "Wymagana jest co najmniej jedna cena.",
+            "uahRequired": "Dla standardowego storefrontu wymagana jest cena w UAH.",
+            "priceRequiredWhenOriginalSet": "{currency}: cena jest wymagana, gdy ustawiono cenę pierwotną.",
+            "invalidMoneyValue": "Nieprawidłowa kwota: \"{value}\"",
+            "invalidPriceValue": "Nieprawidłowa wartość ceny.",
+            "securityMissing": "Brakuje tokenu bezpieczeństwa. Odśwież stronę i spróbuj ponownie.",
+            "slugConflict": "Ten slug jest już używany. Spróbuj zmienić tytuł.",
+            "photoUpdateFailed": "Nie udało się zaktualizować zdjęć produktu",
+            "saleOriginalRequired": "Dla SALE wymagana jest cena pierwotna.",
+            "saleOriginalGreater": "Dla SALE cena pierwotna musi być wyższa od bieżącej.",
+            "securityExpired": "Token bezpieczeństwa wygasł. Odśwież stronę i spróbuj ponownie.",
+            "createFailed": "Nie udało się utworzyć produktu",
+            "updateFailed": "Nie udało się zaktualizować produktu",
+            "unexpectedCreate": "Nieoczekiwany błąd podczas tworzenia produktu.",
+            "unexpectedUpdate": "Nieoczekiwany błąd podczas aktualizowania produktu."
+          }
         }
       },
       "statusToggle": {
@@ -780,6 +870,40 @@
           "previousFailed": "Poprzednia próba płatności nie powiodła się. Spróbuj ponownie",
           "completePayment": "Dokończ płatność, aby sfinalizować zamówienie"
         }
+      },
+      "paymentClient": {
+        "aria": {
+          "form": "Formularz płatności Stripe",
+          "paymentsDisabled": "Płatności wyłączone",
+          "paymentInitializationFailed": "Nie udało się zainicjować płatności",
+          "nextSteps": "Dalsze kroki",
+          "securePayment": "Bezpieczna płatność"
+        },
+        "summary": {
+          "payLabel": "Do zapłaty"
+        },
+        "messages": {
+          "notReady": "Płatność nie jest jeszcze gotowa. Spróbuj ponownie za chwilę.",
+          "confirmFailed": "Nie udało się potwierdzić płatności.",
+          "unexpectedConfirmFailed": "Nie udało się potwierdzić płatności. Spróbuj ponownie.",
+          "paymentsDisabled": "Płatności są wyłączone w tym środowisku.",
+          "initializationFailed": "Nie można zainicjować płatności. Spróbuj ponownie później.",
+          "preparing": "Przygotowywanie bezpiecznej płatności..."
+        },
+        "actions": {
+          "processing": "Przetwarzanie...",
+          "submit": "Potwierdź płatność",
+          "continue": "Kontynuuj",
+          "backToCart": "Powrót do koszyka",
+          "returnToCart": "Wróć do koszyka"
+        }
+      },
+      "errorPage": {
+        "metaTitle": "Błąd realizacji zamówienia | DevLovers",
+        "metaDescription": "Nie udało się dokończyć składania zamówienia. Spróbuj ponownie lub skontaktuj się z pomocą.",
+        "checkoutNavigation": "Nawigacja realizacji zamówienia",
+        "orderDetails": "Szczegóły zamówienia",
+        "nextSteps": "Dalsze kroki"
       },
       "actions": {
         "backToProducts": "Wróć do produktów",

--- a/frontend/messages/uk.json
+++ b/frontend/messages/uk.json
@@ -574,6 +574,96 @@
           "active": "Активний",
           "hidden": "Приховано",
           "featured": "Вітрина"
+        },
+        "form": {
+          "headings": {
+            "create": "Створити новий товар",
+            "edit": "Редагувати товар"
+          },
+          "sections": {
+            "basicInfo": "Основна інформація",
+            "inventorySku": "Запаси та SKU",
+            "catalogAttributes": "Атрибути каталогу",
+            "variants": "Варіанти",
+            "flagsBadge": "Прапорці та значок",
+            "description": "Опис",
+            "photoManagement": "Керування фото"
+          },
+          "fields": {
+            "title": "Назва",
+            "slug": "Slug",
+            "slugHelp": "Автоматично створюється з назви",
+            "price": "Ціна ({currency})",
+            "originalPrice": "Початкова ціна ({currency})",
+            "stock": "Запас",
+            "sku": "SKU",
+            "category": "Категорія",
+            "selectCategory": "Оберіть категорію",
+            "type": "Тип",
+            "selectType": "Оберіть тип",
+            "colors": "Кольори",
+            "sizes": "Розміри",
+            "badge": "Значок",
+            "isActive": "Активний",
+            "isFeatured": "Рекомендований",
+            "description": "Опис",
+            "photos": "Фото"
+          },
+          "badge": {
+            "none": "Немає",
+            "sale": "SALE",
+            "new": "NEW"
+          },
+          "pricing": {
+            "legend": "Ціни",
+            "helper": "UAH є обов'язковою для стандартної вітрини. USD необов'язкова й зберігається лише для сумісності.",
+            "uahLegend": "UAH (стандартна вітрина)",
+            "usdLegend": "USD (необов'язкова сумісність)",
+            "policyPrefix": "Стандартна вітрина оформлює замовлення в UAH. Збережіть рядок UAH у",
+            "policySuffix": "для валюти стандартної вітрини. USD потрібна лише для сумісності."
+          },
+          "photos": {
+            "helper": "Додайте одне або кілька фото, змініть їх порядок і позначте рівно одне як основне.",
+            "photoAlt": "Фото товару {index}",
+            "photoLabel": "Фото {index}",
+            "primary": "Основне",
+            "status": {
+              "saved": "Збережено",
+              "legacy": "Застаріле зображення",
+              "new": "Нове завантаження"
+            },
+            "actions": {
+              "setPrimary": "Зробити основним",
+              "moveUp": "Перемістити вгору",
+              "moveDown": "Перемістити вниз",
+              "remove": "Видалити"
+            }
+          },
+          "actions": {
+            "creating": "Створення...",
+            "updating": "Оновлення...",
+            "create": "Створити товар",
+            "save": "Зберегти зміни"
+          },
+          "errors": {
+            "legacyPhotoMigrationRequired": "Застарілі фото товару потрібно перенести перед додаванням або зміною порядку фото в галереї.",
+            "photoRequired": "Потрібне хоча б одне фото товару.",
+            "atLeastOnePrice": "Потрібна хоча б одна ціна.",
+            "uahRequired": "Для стандартної вітрини обов'язкова ціна в UAH.",
+            "priceRequiredWhenOriginalSet": "{currency}: ціна обов'язкова, якщо вказано початкову ціну.",
+            "invalidMoneyValue": "Некоректне значення суми: \"{value}\"",
+            "invalidPriceValue": "Некоректне значення ціни.",
+            "securityMissing": "Відсутній токен безпеки. Оновіть сторінку й спробуйте ще раз.",
+            "slugConflict": "Такий slug уже використовується. Спробуйте змінити назву.",
+            "photoUpdateFailed": "Не вдалося оновити фото товару",
+            "saleOriginalRequired": "Для SALE потрібна початкова ціна.",
+            "saleOriginalGreater": "Для SALE початкова ціна має бути більшою за поточну.",
+            "securityExpired": "Токен безпеки прострочений. Оновіть сторінку й спробуйте ще раз.",
+            "createFailed": "Не вдалося створити товар",
+            "updateFailed": "Не вдалося оновити товар",
+            "unexpectedCreate": "Неочікувана помилка під час створення товару.",
+            "unexpectedUpdate": "Неочікувана помилка під час оновлення товару."
+          }
         }
       },
       "statusToggle": {
@@ -780,6 +870,40 @@
           "previousFailed": "Попередня спроба оплати не вдалася. Будь ласка, спробуйте ще раз",
           "completePayment": "Завершіть оплату, щоб завершити замовлення"
         }
+      },
+      "paymentClient": {
+        "aria": {
+          "form": "Форма оплати Stripe",
+          "paymentsDisabled": "Оплату вимкнено",
+          "paymentInitializationFailed": "Не вдалося ініціалізувати оплату",
+          "nextSteps": "Наступні кроки",
+          "securePayment": "Безпечна оплата"
+        },
+        "summary": {
+          "payLabel": "До сплати"
+        },
+        "messages": {
+          "notReady": "Оплата ще не готова. Спробуйте ще раз за мить.",
+          "confirmFailed": "Не вдалося підтвердити оплату.",
+          "unexpectedConfirmFailed": "Не вдалося підтвердити оплату. Спробуйте ще раз.",
+          "paymentsDisabled": "У цьому середовищі оплату вимкнено.",
+          "initializationFailed": "Не вдалося ініціалізувати оплату. Спробуйте пізніше.",
+          "preparing": "Готуємо безпечну оплату..."
+        },
+        "actions": {
+          "processing": "Обробка...",
+          "submit": "Підтвердити оплату",
+          "continue": "Продовжити",
+          "backToCart": "Назад до кошика",
+          "returnToCart": "Повернутися до кошика"
+        }
+      },
+      "errorPage": {
+        "metaTitle": "Помилка оформлення | DevLovers",
+        "metaDescription": "Не вдалося завершити оформлення замовлення. Спробуйте ще раз або зверніться до підтримки.",
+        "checkoutNavigation": "Навігація оформлення замовлення",
+        "orderDetails": "Деталі замовлення",
+        "nextSteps": "Наступні кроки"
       },
       "actions": {
         "backToProducts": "Назад до товарів",


### PR DESCRIPTION
## Description

This PR implements **Batch CP-01 — Commercial Policy Refactor on Stabilized Shop Baseline**.

The goal of this batch is to remove the incorrect coupling between `locale` and commercial behavior (currency, payment providers, shipping), while preserving all stabilized shop flows.

Key outcome:
- `locale` now controls **language/content only**
- standard storefront is **UAH across all locales**
- payment providers (Stripe, Monobank) are **env/capability-driven, not locale-driven**
- checkout is **server-authoritative and locale-agnostic**
- USD remains **compatibility-only (not a business requirement)**
- no schema changes, no intl refactor, no regression in existing flows

---

## Related Issue

**Issue**: #<issue_number>

---

## Changes

### PR-A — Policy memo + test repair
- Added commercial policy decision document
- Fixed stale tests blocked by `LEGAL_CONSENT_REQUIRED`
- Ensured tests reach real assertions

### PR-B — Centralized commercial policy
- Introduced centralized policy layer:
  - `commercial-policy.ts`
  - `commercial-policy.server.ts`
- Removed locale as source of truth for currency/provider logic

### PR-C — Storefront read-path switch
- Catalog, PDP, cart now use policy-based currency (UAH)
- Product visibility no longer depends on USD rows
- Monobank visibility no longer tied to locale
- Shipping methods work on non-uk locales

### PR-D — Checkout/server enforcement
- Checkout no longer derives currency from locale
- Orders persist `UAH` across all locales
- Provider selection is locale-agnostic
- Client cannot influence order currency
- Snapshots and Monobank invariants preserved

### PR-E — Acceptance & regression gate
- Added targeted regression tests
- Added acceptance checklist and report
- Verified no regressions in stabilized flows

### PR-F — Admin pricing cleanup
- Enforced UAH as required currency in admin flows
- USD remains optional compatibility only
- Updated validation, services, and tests accordingly

### Additional improvements
- Unified UAH formatting across locales (`uk-UA` formatting everywhere)
- Localized touched UI surfaces (ProductForm, Cart, Checkout UI)
- Cleaned up test wording and reviewer-bait inconsistencies

---

## Database Changes (if applicable)

- [ ] Schema migration required
- [ ] Seed data updated
- [ ] Breaking changes to existing queries
- [ ] Transaction-safe migration
- [ ] Migration tested locally on Neon

> No schema changes in this batch by design (CP-01 constraint)

---

## How Has This Been Tested?

- [x] Tested locally
- [ ] Verified in development environment
- [x] Checked responsive layout (if UI-related)
- [ ] Tested accessibility (keyboard / screen reader)

### Test strategy

- Local Postgres only (guarded)
- PowerShell-based execution
- Targeted Vitest suites:
  - storefront read policy
  - checkout currency enforcement
  - provider visibility
  - shipping methods
  - admin pricing contract
  - currency formatting
- No unnecessary wide test runs

---

## Screenshots (if applicable)

- UAH price formatting unified across locales
- Admin product form localized
- Cart and checkout UI localized

---

## Checklist

### Before submitting

- [x] Code has been self-reviewed
- [x] No TypeScript or console errors
- [x] Code follows project conventions
- [x] Scope is limited to this feature/fix
- [x] No unrelated refactors included
- [x] English used in code, commits, and docs
- [x] New dependencies discussed with team
- [ ] Database migration tested locally (if applicable)
- [ ] GitHub Projects card moved to **In Review**

---

## Reviewers

- [ ] @ViktorSvertoka
- [ ] @AndrewMotko
- [ ] @LesiaUKR 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-language support (en/uk/pl) for the admin product form, checkout UI, and error page metadata.

* **Improvements**
  * Storefront currency/results standardized to UAH across locales; checkout/payment option behavior made consistent.
  * Localized payment client copy, ARIA labels, and clearer validation/error messages for pricing and photo uploads.
  * Payment provider selection and availability now follow a unified storefront policy.

* **Documentation**
  * Added commercial-policy guidance and acceptance checklist for storefront/currency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->