### PR TITLE
(SP: 1) [SHOP] fix stale TEST_LEGAL_CONSENT import in test helper

### DIFF
--- a/frontend/lib/tests/helpers/makeCheckoutReq.ts
+++ b/frontend/lib/tests/helpers/makeCheckoutReq.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 
 import { deriveTestIpFromIdemKey } from '@/lib/tests/helpers/ip';
-import { TEST_LEGAL_CONSENT } from '@/lib/tests/shop/test-legal-consent';
+import { createTestLegalConsent } from '@/lib/tests/shop/test-legal-consent';
 
 export type CheckoutItemInput = {
   productId: string;
@@ -59,7 +59,7 @@ export function makeCheckoutReq(params: {
       items: payloadItems,
       ...(params.legalConsent === null
         ? {}
-        : { legalConsent: params.legalConsent ?? TEST_LEGAL_CONSENT }),
+        : { legalConsent: params.legalConsent ?? createTestLegalConsent() }),
       ...(params.userId ? { userId: params.userId } : {}),
     }),
   });


### PR DESCRIPTION
## Description

Fixes a build-breaking TypeScript error caused by a stale `TEST_LEGAL_CONSENT` import after migrating to the `createTestLegalConsent()` factory.

The helper `makeCheckoutReq` was still importing a removed constant, which caused Netlify build to fail during type checking. The fix updates the helper to use the runtime factory instead of a cached import-time value, aligning test helpers with the current legal-consent contract.

---

## Related Issue

**Issue**: #<issue_number>

---

## Changes

- Replaced stale `TEST_LEGAL_CONSENT` import with `createTestLegalConsent()` in test helper
- Updated helper to generate consent at call-time instead of relying on cached values
- Ensured compatibility with updated legal-consent test contract

---

## Database Changes (if applicable)

- [ ] Schema migration required
- [ ] Seed data updated
- [ ] Breaking changes to existing queries
- [ ] Transaction-safe migration
- [ ] Migration tested locally on Neon

---

## How Has This Been Tested?

- [x] Tested locally
- [x] Verified in development environment
- [ ] Checked responsive layout (if UI-related)
- [ ] Tested accessibility (keyboard / screen reader)

---

## Screenshots (if applicable)

N/A

---

## Checklist

### Before submitting

- [x] Code has been self-reviewed
- [x] No TypeScript or console errors
- [x] Code follows project conventions
- [x] Scope is limited to this feature/fix
- [x] No unrelated refactors included
- [x] English used in code, commits, and docs
- [ ] New dependencies discussed with team
- [ ] Database migration tested locally (if applicable)
- [x] GitHub Projects card moved to **In Review**

---

## Reviewers

- [ ] @ViktorSvertoka
- [ ] @AndrewMotko

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test helper for checkout requests to improve legal consent value generation during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->