### PR TITLE
fix(homepage): guard blog category load

### DIFF
--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -10,10 +10,32 @@ import { CookieBanner } from '@/components/shared/CookieBanner';
 import Footer from '@/components/shared/Footer';
 import { ScrollWatcher } from '@/components/shared/ScrollWatcher';
 import { ThemeProvider } from '@/components/theme/ThemeProvider';
-import { getCachedBlogCategories } from '@/db/queries/blog/blog-categories';
 import { AuthProvider } from '@/hooks/useAuth';
 import { locales } from '@/i18n/config';
 import { readServerEnv } from '@/lib/env/server-env';
+
+type BlogCategory = {
+  id: string;
+  slug: string;
+  title: string;
+};
+
+async function getLayoutBlogCategories(locale: string): Promise<BlogCategory[]> {
+  try {
+    const { getCachedBlogCategories } = await import(
+      '@/db/queries/blog/blog-categories'
+    );
+
+    return await getCachedBlogCategories(locale);
+  } catch (error) {
+    console.error(
+      `[layout] failed to load blog categories for locale "${locale}"`,
+      error
+    );
+
+    return [];
+  }
+}
 
 export default async function LocaleLayout({
   children,
@@ -28,7 +50,7 @@ export default async function LocaleLayout({
 
   const [messages, blogCategories] = await Promise.all([
     getMessages({ locale }),
-    getCachedBlogCategories(locale),
+    getLayoutBlogCategories(locale),
   ]);
 
   const enableAdmin =

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -12,7 +12,9 @@ export async function generateMetadata({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'homepage' });
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://devlovers.net';
+  const siteUrl = (
+    process.env.NEXT_PUBLIC_SITE_URL ?? 'https://devlovers.net'
+  ).replace(/\/$/, '');
   const canonicalUrl =
     locale === 'en' ? `${siteUrl}/en` : `${siteUrl}/${locale}`;
   const localeMap: Record<string, string> = {


### PR DESCRIPTION
## Description

Prevents optional blog category navigation data from crashing the localized homepage layout when database access fails.

Also normalizes `NEXT_PUBLIC_SITE_URL` before building homepage canonical and alternate metadata links, avoiding double slashes like `//uk`.

---

## Related Issue

**Issue**: N/A

---

## Changes

- Guard optional blog category loading in the locale layout
- Return an empty category list when blog categories cannot be loaded
- Leave locale message loading unchanged
- Normalize homepage metadata URLs when `NEXT_PUBLIC_SITE_URL` has a trailing slash

---

## Database Changes (if applicable)

- [ ] Schema migration required
- [ ] Seed data updated
- [ ] Breaking changes to existing queries
- [ ] Transaction-safe migration
- [ ] Migration tested locally on Neon

N/A, no database schema or query changes.

---

## How Has This Been Tested?

- [x] Tested locally
- [ ] Verified in development environment
- [ ] Checked responsive layout (if UI-related)
- [ ] Tested accessibility (keyboard / screen reader)

Tested locally with the Next.js dev server:

- `/uk` loads successfully
- `/en` loads successfully
- Verified the homepage no longer returns 500 when blog category loading fails
- Ran lint/checks for the changed files

---

## Screenshots (if applicable)

N/A

---

## Checklist

### Before submitting

- [x] Code has been self-reviewed
- [x] No TypeScript or console errors
- [x] Code follows project conventions
- [x] Scope is limited to this feature/fix
- [x] No unrelated refactors included
- [x] English used in code, commits, and docs
- [x] No new dependencies added
- [ ] Database migration tested locally (if applicable)
- [ ] GitHub Projects card moved to **In Review**

---

## Reviewers

- [x] @ViktorSvertoka
- [ ] @AndrewMotko

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site URL handling so generated links are consistently formatted, avoiding issues with trailing slashes.
  * Made blog category loading more resilient by falling back gracefully if category data can’t be retrieved, helping pages continue to load smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->