### PR TITLE
chore(release): prepare v1.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1056,3 +1056,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Preserved literal slug/title types in `categoryRegistry` factory to avoid widening to `string`
 - UI polish:
   - Brightened Django category accent color for better readability on dark theme
+
+## [1.0.13] - 2026-07-18
+
+### Added
+
+- New category visual support:
+  - Added Go, GraphQL, NestJS, and NuxtJS to the centralized category registry
+  - Added SVG icons and category-specific accent styles for all four categories
+
+### Changed
+
+- Category styling architecture:
+  - Derived category slug typing directly from `categoryRegistry`
+  - Made generated category styles exhaustive for every registered category
+- Layout runtime resilience:
+  - Changed blog category loading to a guarded dynamic query with an empty-state fallback
+- Homepage SEO:
+  - Normalized the configured site URL before generating localized canonical URLs
+
+### Fixed
+
+- Prevented locale layout rendering from failing when blog category loading throws at runtime
+- Prevented duplicate slashes in homepage canonical URLs when `NEXT_PUBLIC_SITE_URL` ends with `/`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "dependencies": {
         "@neondatabase/serverless": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- bump frontend version from `1.0.12` to `1.0.13`
- synchronize version metadata in `package.json` and `package-lock.json`
- add the `1.0.13` release entry to `CHANGELOG.md`

## Release highlights

- Go, GraphQL, NestJS, and NuxtJS category icons and styles
- exhaustive registry-driven category style typing
- guarded blog category loading in locale layout
- normalized homepage canonical URL generation

## Validation

- release metadata is synchronized at `1.0.13`
- this PR contains only the three release metadata files
- feature changes were previously reviewed and merged in #454